### PR TITLE
work in progress vendoring of argon2 1.3.0

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -17,6 +17,12 @@
 #  location: "./custom-snapshot.yaml"
 resolver: lts-7.5
 
+
+packages:
+- '.'
+- location:
+    git: git@github.com:cartazio/argon2.git
+    commit: f5c2b02d1f09510f9e4964dadb53f7da4b1859bb
 # User packages to be built.
 # Various formats can be used as shown in the example below.
 # 
@@ -35,12 +41,10 @@ resolver: lts-7.5
 # A package marked 'extra-dep: true' will only be built if demanded by a
 # non-dependency (i.e. a user package), and its test suites and benchmarks
 # will not be run. This is useful for tweaking upstream packages.
-packages:
-- '.'
+
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
 extra-deps:
-  - argon2-1.2.0
   - BerkeleyDB-0.8.7
   - logging-3.0.4
   - saltine-0.0.0.4

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,12 +17,6 @@
 #  location: "./custom-snapshot.yaml"
 resolver: lts-7.5
 
-
-packages:
-- '.'
-- location:
-    git: git@github.com:cartazio/argon2.git
-    commit: f5c2b02d1f09510f9e4964dadb53f7da4b1859bb
 # User packages to be built.
 # Various formats can be used as shown in the example below.
 # 
@@ -41,6 +35,10 @@ packages:
 # A package marked 'extra-dep: true' will only be built if demanded by a
 # non-dependency (i.e. a user package), and its test suites and benchmarks
 # will not be run. This is useful for tweaking upstream packages.
+packages:
+- '.'
+- location: https://github.com/jpmorganchase/constellation/files/590600/argon2-1.3.0.tar.gz
+
 
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)


### PR DESCRIPTION
until argon2 has some changes to certain c library symbols, we need to use a patched version,
this patch points stack at the git repo that has fix
see https://github.com/jpmorganchase/constellation/issues/1 for more info / context

still to do: validate that it works/builds on more than one mac computer and also linux too!

what still needs to be done later: make sure the fix is upstreamed and or switch to using the fixed sdist https://github.com/jpmorganchase/constellation/files/590600/argon2-1.3.0.tar.gz