### PR TITLE
Improved config and command line options and addition of passwords file

### DIFF
--- a/Constellation/Enclave.hs
+++ b/Constellation/Enclave.hs
@@ -22,8 +22,8 @@ data Enclave = Enclave
     , enclaveComboCache :: TVar (HM.HashMap (PublicKey, PublicKey) Box.CombinedKey)
     }
 
-newEnclave :: [(FilePath, FilePath)] -> IO (Either String Enclave)
-newEnclave keyPaths = loadKeyPairs keyPaths >>= \case
+newEnclave :: [(FilePath, FilePath, Maybe String)] -> IO (Either String Enclave)
+newEnclave keys = loadKeyPairs keys >>= \case
     Left err  -> return $ Left err
     Right kps -> Right <$> newEnclave' kps
 

--- a/Constellation/Enclave.hs
+++ b/Constellation/Enclave.hs
@@ -23,7 +23,7 @@ data Enclave = Enclave
     }
 
 newEnclave :: [(FilePath, FilePath, Maybe String)] -> IO (Either String Enclave)
-newEnclave keys = loadKeyPairs keys >>= \case
+newEnclave ks = loadKeyPairs ks >>= \case
     Left err  -> return $ Left err
     Right kps -> Right <$> newEnclave' kps
 

--- a/Constellation/Enclave/Key.hs
+++ b/Constellation/Enclave/Key.hs
@@ -32,7 +32,7 @@ loadKeyPair (pubPath, privPath, mpwd) = runEitherT $ do
     privBs <- EitherT $ case mpwd of
         Just pwd -> return $ unlock pwd locked
         Nothing  -> promptingUnlock locked
-    liftIO $ putStrLn $ "Unlocked" ++ privPath
+    liftIO $ putStrLn $ "Unlocked " ++ privPath
     (pub,) <$> maybeToEitherT "Failed to S.encode privBs" (S.decode privBs)
 
 loadKeyPairs :: [(FilePath, FilePath, Maybe String)]

--- a/Constellation/Node/Config.hs
+++ b/Constellation/Node/Config.hs
@@ -55,16 +55,22 @@ instance FromJSON Config where
     -- JSON instance for conversion from TOML
     parseJSON (Object v) = do
         -- DEPRECATE: Backwards compatibility with v0.0.1 config format
-        moldOnodes <- v .:? "otherNodeUrls"
-        case moldOnodes of
-            Just oldOnodes -> do
-                cfg      <- parse
-                pubKeys  <- maybeToList <$> v .:? "publicKeyPath"
-                privKeys <- maybeToList <$> v .:? "privateKeyPath"
+        moldPrivPath <- v .:? "privateKeyPath"
+        case moldPrivPath of
+            Just oldPrivPath -> do
+                cfg        <- parse
+                msocket    <- v .:? "socketPath"
+                otherNodes <- v .:? "otherNodeUrls" .!= []
+                pubKeys    <- maybeToList <$> v .:? "publicKeyPath"
+                storage    <- v .:? "storagePath" .!= "storage"
+                ipwl       <- v .:? "ipWhitelist" .!= []
                 return cfg
-                    { cfgOtherNodes  = oldOnodes
+                    { cfgSocket      = msocket
+                    , cfgOtherNodes  = otherNodes
                     , cfgPublicKeys  = pubKeys
-                    , cfgPrivateKeys = privKeys
+                    , cfgPrivateKeys = [oldPrivPath]
+                    , cfgStorage     = storage
+                    , cfgIpWhitelist = ipwl
                     }
             Nothing        -> parse
       where

--- a/Constellation/Node/Config.hs
+++ b/Constellation/Node/Config.hs
@@ -5,16 +5,14 @@
 module Constellation.Node.Config where
 
 import ClassyPrelude
-import Control.Logging (errorL')
 import Data.Aeson
-    (FromJSON(parseJSON), Value(Object), (.:), (.:?), (.!=), toJSON, fromJSON)
+    (FromJSON(parseJSON), Value(Object), (.:?), (.!=), toJSON, fromJSON)
 import Data.Default (Default, def)
 import Data.List.Split (splitOn)
 import System.Console.GetOpt
     ( OptDescr(Option), ArgOrder(Permute), ArgDescr(NoArg, OptArg)
     , getOpt, usageInfo
     )
-import System.Exit (exitSuccess)
 import Text.Read (read)
 import Text.Toml (parseTomlDoc)
 import qualified Data.Aeson as AE
@@ -185,7 +183,7 @@ extractConfig argv = case getOpt Permute options argv of
     (_, _, errs) -> errorOut (concat errs)
 
 errorOut :: String -> IO a
-errorOut s = ioError (userError $ s ++ ". " ++ usageInfo header options) >> undefined
+errorOut s = ioError (userError $ s ++ ". " ++ usageInfo header options) >> error ""
   where
     header = "Usage: constellation-node [OPTION...] [config file containing options]\n(If a configuration file is specified, any command line options will take precedence.)"
 

--- a/Constellation/Node/Config.hs
+++ b/Constellation/Node/Config.hs
@@ -4,6 +4,7 @@
 module Constellation.Node.Config where
 
 import ClassyPrelude
+import Control.Logging (errorL')
 import Data.Aeson
     (FromJSON(parseJSON), Value(Object), (.:), (.:?), (.!=), toJSON, fromJSON)
 import Data.Default (Default, def)
@@ -111,7 +112,7 @@ options =
     , Option [] ["privatekeys"] (OptArg (justDo setPrivateKeys) "FILES")
       "Comma-separated list of paths to corresponding private keys (these must be given in the same order as --publickeys)"
 
-    , Option [] ["password"] (OptArg (justDo setPasswords) "FILE")
+    , Option [] ["passwords"] (OptArg (justDo setPasswords) "FILE")
       "A file containing the passwords for the specified --privatekeys, one per line, in the same order (if one key is not locked, add an empty line)"
 
     , Option [] ["storage"] (OptArg (justDo setStorage) "FILE")

--- a/Constellation/Node/Config.hs
+++ b/Constellation/Node/Config.hs
@@ -29,6 +29,7 @@ data Config = Config
     , cfgOtherNodeUrls   :: ![Text]
     , cfgPublicKeyPaths  :: ![FilePath]
     , cfgPrivateKeyPaths :: ![FilePath]
+    , cfgPasswordsPath   :: !FilePath
     , cfgStoragePath     :: !String
     , cfgIpWhitelist     :: ![String]
     , cfgJustShowVersion :: !Bool
@@ -43,6 +44,7 @@ instance Default Config where
         , cfgOtherNodeUrls   = []
         , cfgPublicKeyPaths  = []
         , cfgPrivateKeyPaths = []
+        , cfgPasswordsPath   = ""
         , cfgStoragePath     = "storage"
         , cfgIpWhitelist     = []
         , cfgJustShowVersion = False
@@ -61,19 +63,22 @@ options =
     , Option [] ["port"] (OptArg (justDo setPort) "PORT")
       "Port to listen on for the external API"
 
-    , Option [] ["socketpath"] (OptArg (justDo setSocketPath) "FILE")
+    , Option [] ["socket"] (OptArg (justDo setSocketPath) "FILE")
       "Path to IPC socket file to create for internal API access"
 
     , Option [] ["othernodeurls"] (OptArg (justDo setOtherNodeUrls) "URLs")
       "Comma-separated list of other node URLs to connect to on startup (this list may be incomplete)"
 
-    , Option [] ["publickeys", "publickey", "publickeypath"] (OptArg (justDo setPublicKeyPaths) "FILE")
+    , Option [] ["publickeys"] (OptArg (justDo setPublicKeyPaths) "FILE")
       "Comma-separated list of paths to public keys to advertise"
 
-    , Option [] ["privatekeys", "privatekey", "privatekeypath"] (OptArg (justDo setPrivateKeyPaths) "FILE")
+    , Option [] ["privatekeys"] (OptArg (justDo setPrivateKeyPaths) "FILE")
       "Comma-separated list of paths to corresponding private keys (these must be given in the same order as --publickeys)"
 
-    , Option [] ["storage", "storagepath"] (OptArg (justDo setStoragePath) "FILE")
+    , Option [] ["password"] (OptArg (justDo setPasswordsPath) "FILE")
+      "A file containing the passwords for the specified --privatekeys, one per line, in the same order (if one key is not locked, add an empty line)"
+
+    , Option [] ["storage"] (OptArg (justDo setStoragePath) "FILE")
       "Storage path to pass to the storage engine"
 
     , Option [] ["ipwhitelist"] (OptArg (justDo setIpWhitelist) "IPv4s/IPv6s")
@@ -107,6 +112,9 @@ setPublicKeyPaths s c = c { cfgPublicKeyPaths = map trimBoth (splitOn "," s) }
 
 setPrivateKeyPaths :: String -> Config -> Config
 setPrivateKeyPaths s c = c { cfgPrivateKeyPaths = map trimBoth (splitOn "," s) }
+
+setPasswordsPath :: String -> Config -> Config
+setPasswordsPath s c = c { cfgPasswordsPath = s }
 
 setStoragePath :: String -> Config -> Config
 setStoragePath s c = c { cfgSocketPath = T.pack s }

--- a/Constellation/Node/Config.hs
+++ b/Constellation/Node/Config.hs
@@ -103,13 +103,13 @@ options =
     , Option [] ["socket"] (OptArg (justDo setSocket) "FILE")
       "Path to IPC socket file to create for internal API access"
 
-    , Option [] ["othernodes"] (OptArg (justDo setOtherNodes) "URLS")
+    , Option [] ["othernodes"] (OptArg (justDo setOtherNodes) "URL...")
       "Comma-separated list of other node URLs to connect to on startup (this list may be incomplete)"
 
-    , Option [] ["publickeys"] (OptArg (justDo setPublicKeys) "FILES")
+    , Option [] ["publickeys"] (OptArg (justDo setPublicKeys) "FILE...")
       "Comma-separated list of paths to public keys to advertise"
 
-    , Option [] ["privatekeys"] (OptArg (justDo setPrivateKeys) "FILES")
+    , Option [] ["privatekeys"] (OptArg (justDo setPrivateKeys) "FILE...")
       "Comma-separated list of paths to corresponding private keys (these must be given in the same order as --publickeys)"
 
     , Option [] ["passwords"] (OptArg (justDo setPasswords) "FILE")
@@ -118,7 +118,7 @@ options =
     , Option [] ["storage"] (OptArg (justDo setStorage) "FILE")
       "Storage path to pass to the storage engine"
 
-    , Option [] ["ipwhitelist"] (OptArg (justDo setIpWhitelist) "IPS")
+    , Option [] ["ipwhitelist"] (OptArg (justDo setIpWhitelist) "IP...")
       "Comma-separated list of IPv4 and IPv6 addresses that may connect to this node's external API"
 
     , Option ['v'] ["verbosity"] (OptArg setVerbosity "NUM")
@@ -184,7 +184,7 @@ extractConfig argv = case getOpt Permute options argv of
     (_, _, errs) -> errorOut (concat errs)
 
 errorOut :: String -> IO a
-errorOut s = ioError (userError $ s ++ usageInfo header options) >> undefined
+errorOut s = ioError (userError $ s ++ ". " ++ usageInfo header options) >> undefined
   where
     header = "Usage: constellation-node [OPTION...] [config file containing options]\n(If a configuration file is specified, any command line options will take precedence.)"
 

--- a/Constellation/Node/Config.hs
+++ b/Constellation/Node/Config.hs
@@ -5,6 +5,9 @@ module Constellation.Node.Config where
 import ClassyPrelude
 import Data.Aeson
     (FromJSON(parseJSON), Value(Object), (.:), (.:?), (.!=), toJSON, fromJSON)
+import Data.Default (Default, def)
+import System.Console.GetOpt (OptDescr, Option)
+import System.Exit (exitSuccess)
 import Text.Toml (parseTomlDoc)
 import qualified Data.Aeson as AE
 import qualified Data.Text.IO as TIO
@@ -20,7 +23,23 @@ data Config = Config
     , cfgPrivateKeyPath         :: !FilePath
     , cfgStoragePath            :: !String
     , cfgIpWhitelist            :: ![String]
+    , cfgJustShowVersion        :: !Bool
+    , cfgVerbose                :: !Bool
     } deriving Show
+
+instance Default Config where
+    def = Config
+        { cfgUrl             = ""
+        , cfgPort            = 0
+        , cfgSocketPath      = "constellation.ipc"
+        , cfgOtherNodeUrls   = []
+        , cfgPublicKeyPath   = ""
+        , cfgPrivateKeyPath  = ""
+        , cfgStoragePath     = "storage"
+        , cfgIpWhitelist     = []
+        , cfgJustShowVersion = False
+        , cfgVerbose         = False
+        }
 
 instance FromJSON Config where
     parseJSON (Object v) = Config
@@ -33,6 +52,78 @@ instance FromJSON Config where
         <*> v .:  "storagePath"
         <*> v .:? "ipWhitelist"   .!= []
     parseJSON _          = mzero
+
+options :: [OptDescr (Config -> Config)]
+options =
+    [ Option [] ["url"] (OptArg $ maybe "" setUrl)
+      "URL for this node (what's advertised to other nodes, e.g. https://constellation.mydomain.com/)"
+
+    , Option [] ["port"] (OptArg $ maybe 0 setPort)
+      "Port to listen on"
+
+    , Option [] ["socketpath"] (OptArg setSocketPath)
+      "Path to IPC socket file"
+
+    , Option [] ["othernodeurls"] (OptArg setOtherNodeUrls)
+      "(Possibly incomplete list of) other node URLs"
+
+    , Option [] ["publickeypath"] (OptArg setPublicKeyPath)
+      "Path to the public key to advertise"
+
+    , Option [] ["privatekeypath"] (OptArg setPrivateKeyPath)
+      "Path to the public key's corresponding private key"
+
+    , Option [] ["storagepath"] (OptArg setStoragePath)
+      "Storage path to pass to the storage engine"
+
+    , Option [] ["ipwhitelist"] (OptArg setIpWhitelist)
+        (OptArg (\c s -> 
+        "Comma-separated list of IPv4 and IPv6 addresses that may connect to this node's external API"
+
+    , Option ['v'] ["verbose"]
+        (NoArg (\c -> c { cfgVerbose = True }))
+        "print more detailed information"
+
+    , Option ['V', '?'] ["version"]
+        (NoArg (\c -> c { cfgJustShowVersion = True }))
+    ]
+
+setUrl :: String -> Config -> Config
+setUrl Nothing  c = c
+setUrl (Just s) c = c { cfgUrl = s }
+
+setPort :: String -> Config -> Config
+setPort Nothing c = c
+setPort (Just s)  = c { cfgPort = read s }
+
+setSocketPath :: String -> Config -> Config
+setSocketPath Nothing c = c
+setSocketPath (Just s)  = c { cfgSocketPath = s }
+
+setOtherNodeUrls :: String -> Config -> Config
+setOtherNodeUrls Nothing c = c
+setOtherNodeUrls (Just s)  = c { cfgOtherNodeUrls = map trimBoth $ splitOn "," s }
+
+setPublicKeyPath :: String -> Config -> Config
+setPublicKeyPath Nothing c = c
+setPublicKeyPath (Just s)  = c { cfgPublicKeyPath = s }
+
+setPrivateKeyPath :: String -> Config -> Config
+setPrivateKeyPath Nothing c = c
+setPrivateKeyPath (Just s)  = c { cfgPrivateKeyPath = s }
+
+setStoragePath :: String -> Config -> Config
+setStoragePath Nothing c = c
+setStoragePath (Just s)  = c { cfgSocketPath = s }
+
+setIpWhitelist :: String -> Config -> Config
+setIpWhitelist s = c { cfgIpWhitelist = map trimBoth $ splitOn "," s }
+
+setVerbose :: Config -> Config
+setVerbose = c { cfgVerbose = True }
+
+setVersion :: Config -> Config
+setVersion = c { cfgJustShowVersion = True }
 
 loadConfigFile :: FilePath -> IO (Either String Config)
 loadConfigFile fpath = do

--- a/Constellation/Node/Main.hs
+++ b/Constellation/Node/Main.hs
@@ -6,7 +6,9 @@ module Constellation.Node.Main where
 import ClassyPrelude hiding (getArgs, log)
 import Control.Concurrent (forkIO)
 import Control.Logging
-    (LogLevel(LevelDebug, LevelWarn), setLogLevel, withStderrLogging, log')
+    ( LogLevel(LevelDebug, LevelInfo, LevelWarn, LevelError)
+    , setLogLevel, withStderrLogging, log'
+    )
 import Data.Text.Format (Shown(Shown))
 import GHC.Conc (getNumProcessors)
 import Network.Socket
@@ -50,7 +52,12 @@ errorOut s = ioError (userError "foo") -- TEMP
 
 run :: Config -> IO ()
 run cfg@Config{..} = do
-    let logLevel = if cfgVerbose then LevelDebug else LevelWarn
+    let logLevel = case cfgVerbosity of
+            0 -> LevelError
+            1 -> LevelWarn
+            2 -> LevelInfo
+            3 -> LevelDebug
+            _ -> LevelDebug
     logf' "Log level is {}" [show logLevel]
     setLogLevel logLevel
     debugf' "Configuration: {}" [show cfg]

--- a/Constellation/Node/Main.hs
+++ b/Constellation/Node/Main.hs
@@ -35,6 +35,9 @@ import Constellation.Util.AtExit (registerAtExit, withAtExit)
 import Constellation.Util.Logging (logf', warnf')
 import qualified Constellation.Node.Api as NodeApi
 
+version :: Text
+version = "0.1"
+
 defaultMain :: IO ()
 defaultMain = do
     args <- getArgs
@@ -43,12 +46,14 @@ defaultMain = do
             logf' "Constellation initializing using config file {}" [cfgPath]
             loadConfigFile (T.unpack cfgPath) >>= \ecfg -> case ecfg of
                 Left err  -> warnf' "Error parsing configuration file: {}" [err]
-                Right cfg -> run cfg
+                Right cfg -> if cfgJustShowVersion cfg $
+                    then putStrLn ("Constellation Node " ++ version)
+                    else run cfg
         _         -> usage
 
 run :: Config -> IO ()
 run Config{..} = do
-    let logLevel = LevelWarn
+    let logLevel = if cfgVerbose then LevelDebug else LevelWarn
     logf' "Log level is {}" [show logLevel]
     setLogLevel logLevel
     ncpus <- getNumProcessors

--- a/Constellation/Node/Main.hs
+++ b/Constellation/Node/Main.hs
@@ -38,7 +38,7 @@ import Constellation.Util.Logging (debugf', logf', warnf')
 import qualified Constellation.Node.Api as NodeApi
 
 version :: Text
-version = "0.1"
+version = "0.0.2-dev"
 
 defaultMain :: IO ()
 defaultMain = do

--- a/Constellation/Node/Main.hs
+++ b/Constellation/Node/Main.hs
@@ -57,7 +57,10 @@ run cfg@Config{..} = do
     setNumCapabilities ncpus
     let kps = zip cfgPublicKeyPaths cfgPrivateKeyPaths
     logf' "Constructing Enclave using keypairs {}" [show kps]
-    ks <- mustLoadKeyPairs kps
+    pwds <- if cfgPasswordsPath == ""
+        then return []
+        else lines <$> readFileUtf8 cfgPasswordsPath
+    ks <- mustLoadKeyPairs pwds kps
     e  <- newEnclave' ks
     let crypt = Crypt
             { encryptPayload = enclaveEncryptPayload e

--- a/Constellation/Node/Main.hs
+++ b/Constellation/Node/Main.hs
@@ -84,8 +84,7 @@ run cfg@Config{..} = do
     storage <- berkeleyDbStorage cfgStorage
     -- storage <- memoryStorage
     nvar    <- newTVarIO =<<
-        newNode crypt storage cfgUrl (map fst ks)
-        cfgOtherNodes
+        newNode crypt storage cfgUrl (map fst ks) cfgOtherNodes
     _ <- forkIO $ do
         let mwl = if null cfgIpWhitelist
                 then Nothing

--- a/Constellation/Node/Main.hs
+++ b/Constellation/Node/Main.hs
@@ -19,7 +19,6 @@ import Network.Socket
 import System.Directory (doesFileExist, removeFile)
 import System.Environment (getArgs)
 import qualified Data.Text as T
-import qualified Data.Text.Format as TF
 import qualified Network.Wai.Handler.Warp as Warp
 
 import Constellation.Enclave
@@ -35,7 +34,7 @@ import Constellation.Node.Types
     )
 import Constellation.Node.Config (Config(..), extractConfig)
 import Constellation.Util.AtExit (registerAtExit, withAtExit)
-import Constellation.Util.Logging (debugf', logf', warnf')
+import Constellation.Util.Logging (debugf', logf')
 import qualified Constellation.Node.Api as NodeApi
 
 version :: Text

--- a/Constellation/Node/Main.hs
+++ b/Constellation/Node/Main.hs
@@ -73,7 +73,8 @@ run cfg@Config{..} = do
     when (cfgPort == 0) $
         errorL' "A listening port must be specified with 'port' in the configuration file or --port at runtime"
     let kps = zip3 cfgPublicKeys cfgPrivateKeys pwds
-    logf' "Constructing Enclave using keypairs {}" [show kps]
+    logf' "Constructing Enclave using keypairs {}"
+        [show $ zip cfgPublicKeys cfgPrivateKeys]
     ks <- mustLoadKeyPairs kps
     e  <- newEnclave' ks
     let crypt = Crypt

--- a/Constellation/Util/Lockable.hs
+++ b/Constellation/Util/Lockable.hs
@@ -173,6 +173,4 @@ promptingUnlock locked       = runInputT defaultSettings prompt
             Just ""  -> prompt
             Just pwd -> case unlock pwd locked of
                 Left _  -> putStrLn "Invalid password. Try again." >> prompt
-                Right b -> do
-                  putStrLn "Unlocked"
-                  return $ Right b
+                Right b -> return $ Right b

--- a/Constellation/Util/Lockable.hs
+++ b/Constellation/Util/Lockable.hs
@@ -150,8 +150,8 @@ lock pwd b = do
 deriveKey :: ArgonSalt -> ArgonOptions -> String -> ByteString
 deriveKey (ArgonSalt asalt) (ArgonOptions hopts) pwd =
     case hash hopts (TE.encodeUtf8 $ T.pack pwd) asalt 32 of
-      CryptoPassed a -> a
-      CryptoFailed e -> error $ "deriveKey failed: " ++ show e
+        CryptoPassed a -> a
+        CryptoFailed e -> error $ "deriveKey failed: " ++ show e
 
 unlock :: String -> Lockable -> Either String ByteString
 unlock _   (Unlocked b)                                  = Right b

--- a/Constellation/Util/String.hs
+++ b/Constellation/Util/String.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+module Constellation.Util.String where
+
+import ClassyPrelude
+import Data.Char (isSpace)
+
+trimLeft :: String -> String
+trimLeft = dropWhile isSpace
+
+trimRight :: String -> String
+trimRight = reverse . trimLeft . reverse
+
+trimBoth :: String -> String
+trimBoth = trimRight . trimLeft

--- a/README.md
+++ b/README.md
@@ -40,41 +40,12 @@ Constellation binaries for most major platforms can be downloaded [here](https:/
 
 ## Running
 
-  1. Run `constellation-node <path to config file>`
+  1. Run `constellation-node <path to config file>` or specify configuration
+     variables as command-line options (see `constellation-node --help`)
 
 For now, please refer to the [Constellation client Go library](https://github.com/jpmorganchase/quorum/blob/master/private/constellation/node.go)
 for an example of how to use Constellation. More detailed documentation coming soon!
 
 ## Configuration File Format
 
-    # Externally accessible URL for this node (this is what's advertised)
-    url = "http://127.0.0.1:9001/"
-
-    # Port to listen on
-    port = 9001
-
-    # Optional IP whitelist for the external API. If unspecified/empty,
-    # connections from all sources will be allowed (but the private API remains
-    # accessible only via the IPC socket below.) To allow connections from
-    # localhost when a whitelist is defined, e.g. when running multiple
-    # Constellation nodes on the same machine, add "127.0.0.1" and "::1" to
-    # this list.
-    ipWhitelist = ["10.0.0.1", "2001:0db8:85a3:0000:0000:8a2e:0370:7334"]
-
-    # Socket file to use for IPC
-    socketPath = "tm1.ipc"
-
-    # Initial (not necessarily complete) list of other nodes in the network.
-    # Constellation will automatically connect to other nodes not in this list
-    # that are advertised by the nodes below, thus these can be considered the
-    # "boot nodes."
-    otherNodeUrls = ["http://127.0.0.1:9000/"]
-
-    # This node's public key
-    publicKeyPath = "tm1.pub"
-
-    # This node's private key
-    privateKeyPath = "tm1.key"
-
-    # Where to store payloads and related information
-    storagePath = "data/payloads"
+See [sample.conf](sample.conf)

--- a/README.md
+++ b/README.md
@@ -48,4 +48,4 @@ for an example of how to use Constellation. More detailed documentation coming s
 
 ## Configuration File Format
 
-See [sample.conf](sample.conf)
+See [sample.conf](sample.conf).

--- a/constellation.cabal
+++ b/constellation.cabal
@@ -74,6 +74,7 @@ library
                      , raw-strings-qq >= 1.1
                      -- , resource-pool
                      , saltine >= 0.0.0.4
+                     , split >= 0.2.3.1
                      -- , sqlite-simple
                      , text >= 1.2.2.1
                      , text-format >= 0.3.1.1

--- a/constellation.cabal
+++ b/constellation.cabal
@@ -39,6 +39,7 @@ library
                        Constellation.Util.Logging
                        Constellation.Util.Memory
                        Constellation.Util.Network
+                       Constellation.Util.String
                        Constellation.Util.Text
                        Constellation.Util.Wai
   ghc-options:         -Wall
@@ -111,6 +112,7 @@ test-suite constellation-test
                        Constellation.Util.Logging.Test
                        Constellation.Util.Memory.Test
                        Constellation.Util.Network.Test
+                       Constellation.Util.String.Test
                        Constellation.Util.Text.Test
                        Constellation.Util.Wai.Test
   main-is:             Main.hs

--- a/sample.conf
+++ b/sample.conf
@@ -21,7 +21,7 @@ privatekeys = ["foo.key"]
 
 # Optional file containing the passwords to unlock the given privatekeys
 # (one password per line -- add an empty line if one key isn't locked.)
-# passwords = passwordsfile
+# passwords = "passwords"
 
 # Where to store payloads and related information
 storage = "data"

--- a/sample.conf
+++ b/sample.conf
@@ -1,18 +1,10 @@
 # Externally accessible URL for this node (this is what's advertised)
 url = "http://127.0.0.1:9001/"
 
-# Port to listen on
+# Port to listen on for the public API
 port = 9001
 
-# Optional IP whitelist for the external API. If unspecified/empty,
-# connections from all sources will be allowed (but the private API remains
-# accessible only via the IPC socket below.) To allow connections from
-# localhost when a whitelist is defined, e.g. when running multiple
-# Constellation nodes on the same machine, add "127.0.0.1" and "::1" to
-# this list.
-ipwhitelist = ["10.0.0.1", "2001:0db8:85a3:0000:0000:8a2e:0370:7334"]
-
-# Socket file to use for IPC
+# Socket file to use for the private API / IPC
 socket = "foo.ipc"
 
 # Initial (not necessarily complete) list of other nodes in the network.
@@ -27,5 +19,24 @@ publickeys = ["foo.pub"]
 # The corresponding set of private keys
 privatekeys = ["foo.key"]
 
+# Optional file containing the passwords to unlock the given privatekeys
+# (one password per line -- add an empty line if one key isn't locked.)
+# passwords = passwordsfile
+
 # Where to store payloads and related information
 storage = "data"
+
+# Optional IP whitelist for the external API. If unspecified/empty,
+# connections from all sources will be allowed (but the private API remains
+# accessible only via the IPC socket above.) To allow connections from
+# localhost when a whitelist is defined, e.g. when running multiple
+# Constellation nodes on the same machine, add "127.0.0.1" and "::1" to
+# this list.
+# ipwhitelist = ["10.0.0.1", "2001:0db8:85a3:0000:0000:8a2e:0370:7334"]
+
+# Verbosity level (each level includes all prior levels)
+#   - 0: Only fatal errors
+#   - 1: Warnings
+#   - 2: Informational messages
+#   - 3: Debug messages
+verbosity = 1

--- a/sample.conf
+++ b/sample.conf
@@ -1,0 +1,31 @@
+# Externally accessible URL for this node (this is what's advertised)
+url = "http://127.0.0.1:9001/"
+
+# Port to listen on
+port = 9001
+
+# Optional IP whitelist for the external API. If unspecified/empty,
+# connections from all sources will be allowed (but the private API remains
+# accessible only via the IPC socket below.) To allow connections from
+# localhost when a whitelist is defined, e.g. when running multiple
+# Constellation nodes on the same machine, add "127.0.0.1" and "::1" to
+# this list.
+ipwhitelist = ["10.0.0.1", "2001:0db8:85a3:0000:0000:8a2e:0370:7334"]
+
+# Socket file to use for IPC
+socket = "foo.ipc"
+
+# Initial (not necessarily complete) list of other nodes in the network.
+# Constellation will automatically connect to other nodes not in this list
+# that are advertised by the nodes below, thus these can be considered the
+# "boot nodes."
+othernodes = ["http://127.0.0.1:9000/"]
+
+# The set of public keys this node will host
+publickeys = ["foo.pub"]
+
+# The corresponding set of private keys
+privatekeys = ["foo.key"]
+
+# Where to store payloads and related information
+storage = "data"

--- a/test/Constellation/Util/String/Test.hs
+++ b/test/Constellation/Util/String/Test.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Constellation.Util.String.Test where
+
+import ClassyPrelude
+import Data.Char (isSpace)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck (testProperty)
+
+import Constellation.Util.String (trimLeft, trimRight, trimBoth)
+
+tests :: TestTree
+tests = testGroup "Util.String"
+    [ testTrimLeft
+    , testTrimRight
+    , testTrimBoth
+    ]
+
+testTrimLeft :: TestTree
+testTrimLeft = testProperty "trimLeft"
+    (\x -> null $ takeWhile isSpace $ trimLeft x)
+
+testTrimRight :: TestTree
+testTrimRight = testProperty "trimRight"
+    (\x -> null $ takeWhile isSpace $ reverse $ trimRight x)
+
+testTrimBoth :: TestTree
+testTrimBoth = testProperty "trimBoth"
+    (\x -> let s = trimBoth x
+            in null (takeWhile isSpace s) &&
+               null (takeWhile isSpace $ reverse s)
+    )

--- a/test/Constellation/Util/String/Test.hs
+++ b/test/Constellation/Util/String/Test.hs
@@ -17,12 +17,11 @@ tests = testGroup "Util.String"
     ]
 
 testTrimLeft :: TestTree
-testTrimLeft = testProperty "trimLeft"
-    (\x -> null $ takeWhile isSpace $ trimLeft x)
+testTrimLeft = testProperty "trimLeft" (null . takeWhile isSpace . trimLeft)
 
 testTrimRight :: TestTree
 testTrimRight = testProperty "trimRight"
-    (\x -> null $ takeWhile isSpace $ reverse $ trimRight x)
+    (null . takeWhile isSpace . reverse . trimRight)
 
 testTrimBoth :: TestTree
 testTrimBoth = testProperty "trimBoth"

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -28,6 +28,7 @@ import qualified Constellation.Util.Exception.Test as UtilException
 import qualified Constellation.Util.Lockable.Test as UtilLockable
 import qualified Constellation.Util.Memory.Test as UtilMemory
 import qualified Constellation.Util.Network.Test as UtilNetwork
+import qualified Constellation.Util.String.Test as UtilString
 import qualified Constellation.Util.Text.Test as UtilText
 import qualified Constellation.Util.Wai.Test as UtilWai
 
@@ -52,6 +53,7 @@ tests = testGroup ""
     , UtilLockable.tests
     , UtilMemory.tests
     , UtilNetwork.tests
+    , UtilString.tests
     , UtilText.tests
     , UtilWai.tests
     ]


### PR DESCRIPTION
- Most configuration options, e.g. the IPC socket path, are now optional, in anticipation of later adding runtime configuration ability. `port` must always be specified either in the configuration file or with `--port`.

- Ability to specify any configuration file parameter on the command line, e.g. `--storage=data`. If a configuration file is given as an argument, the command line options will override the options specified in the file. A configuration file is no longer necessary to launch `constellation-node`.

- Ability to specify `-v [NUM]` or `-vv`, `-vvv` to control verbosity level.

- Ability to output Constellation version and exit using `--version`.

- Ability to specify multiple public/private key pairs using `publickeys` and `privatekeys` in the configuration file, or `--publickeys` and `--privatekeys` on the command line. (The ordering of the public and private keys must match.)

- Ability to specify a file containing passwords for the private keys given (if locked) with `passwords`. Each line contains a password for a key in the same sequence they were given in `privatekeys`. If a key is not locked, but others are, add a blank line for that key's entry in the passwords file.

- Some options have been renamed:
  - `socketPath` is now `socket`
  - `otherNodeUrls` is now `othernodes`
  - `publicKeyPath` is now `publickeys` (a list -- see above)
  - `privateKeyPath` is now `privatekeys` (a list -- see above)
  - `storagePath` is now `storage`
  - `ipWhitelist` is now `ipwhitelist`

    Constellation remains backwards compatible with configuration files using the old naming conventions, however the new and old naming should not be mixed.

- Addition of Util.String containing string trimming functions.