### PR TITLE
Payload deletion support in storage layer

### DIFF
--- a/Constellation/Enclave/Payload.hs
+++ b/Constellation/Enclave/Payload.hs
@@ -17,7 +17,7 @@ data EncryptedPayload = EncryptedPayload
     , eplNonce     :: SBox.Nonce
     , eplRcptBoxes :: [ByteString]
     , eplRcptNonce :: Box.Nonce
-    }
+    } deriving Eq
 
 instance Show EncryptedPayload where
     show = show . encodeable

--- a/Constellation/Node/Storage/BerkeleyDb.hs
+++ b/Constellation/Node/Storage/BerkeleyDb.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE Strict #-}
 module Constellation.Node.Storage.BerkeleyDb where
 
-import ClassyPrelude hiding (hash)
+import ClassyPrelude hiding (delete, hash)
 import Control.Logging (warn, warnS)
 import Crypto.Hash (Digest, SHA3_512, hash)
 import Data.Binary (encode, decode)
@@ -19,7 +19,8 @@ import Constellation.Enclave.Payload
     (EncryptedPayload(EncryptedPayload, eplCt))
 import Constellation.Enclave.Types (PublicKey)
 import Constellation.Node.Types
-    (Storage(Storage, savePayload, loadPayload, traverseStorage, closeStorage))
+    (Storage(Storage, savePayload, loadPayload, deletePayload,
+             traverseStorage, closeStorage))
 import Constellation.Util.Memory (byteArrayToByteString)
 
 berkeleyDbStorage :: FilePath -> IO Storage
@@ -53,6 +54,7 @@ berkeleyDbStorage fpath = do
     return Storage
         { savePayload     = \epl -> rtx $ \tx -> save db (Just tx) epl
         , loadPayload     = load db Nothing
+        , deletePayload   = delete db Nothing
         , traverseStorage = trav db Nothing
         , closeStorage    = do
               db_close [] db
@@ -117,6 +119,14 @@ load db mtx k = do
     return $ case mv of
         Nothing -> Left "Key not found in BerkeleyDb payload.db"
         Just v  -> Right $ decode $ BL.fromStrict v
+
+delete :: Db
+     -> Maybe DbTxn
+     -> Text
+     -> IO ()
+delete db mtx k = do
+    db_del [] db mtx (TE.encodeUtf8 k) >>
+      return ()
 
 trav :: Db
      -> Maybe DbTxn

--- a/Constellation/Node/Storage/BerkeleyDb.hs
+++ b/Constellation/Node/Storage/BerkeleyDb.hs
@@ -124,9 +124,7 @@ delete :: Db
      -> Maybe DbTxn
      -> Text
      -> IO ()
-delete db mtx k = do
-    db_del [] db mtx (TE.encodeUtf8 k) >>
-      return ()
+delete db mtx k = void $ db_del [] db mtx (TE.encodeUtf8 k)
 
 trav :: Db
      -> Maybe DbTxn

--- a/Constellation/Node/Storage/Memory.hs
+++ b/Constellation/Node/Storage/Memory.hs
@@ -47,8 +47,7 @@ load mvar k = atomically $ do
         Just v  -> Right v
 
 delete :: Db -> Text -> IO ()
-delete mvar k = atomically $ do
-    modifyTVar mvar (HM.delete k) >> return ()
+delete mvar k = atomically $ void $ modifyTVar mvar (HM.delete k)
 
 trav :: Db -> (Text -> (EncryptedPayload, [PublicKey]) -> IO Bool) -> IO ()
 trav mvar f = atomically (readTVar mvar) >>= loop . HM.toList

--- a/Constellation/Node/Storage/Memory.hs
+++ b/Constellation/Node/Storage/Memory.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE Strict #-}
 module Constellation.Node.Storage.Memory where
 
-import ClassyPrelude hiding (hash)
+import ClassyPrelude hiding (delete, hash)
 import Crypto.Hash (Digest, SHA3_512, hash)
 import qualified Data.ByteString.Base64 as B64
 import qualified Data.HashMap.Strict as HM
@@ -14,7 +14,8 @@ import Constellation.Enclave.Payload
     (EncryptedPayload(EncryptedPayload, eplCt))
 import Constellation.Enclave.Types (PublicKey)
 import Constellation.Node.Types
-    (Storage(Storage, savePayload, loadPayload, traverseStorage, closeStorage))
+    (Storage(Storage, savePayload, loadPayload, deletePayload,
+             traverseStorage, closeStorage))
 import Constellation.Util.Memory (byteArrayToByteString)
 
 type Db = TVar (HM.HashMap Text (EncryptedPayload, [PublicKey]))
@@ -25,6 +26,7 @@ memoryStorage = do
     return Storage
         { savePayload     = save mvar
         , loadPayload     = load mvar
+        , deletePayload   = delete mvar
         , traverseStorage = trav mvar
         , closeStorage    = return ()
         }
@@ -43,6 +45,10 @@ load mvar k = atomically $ do
     return $ case HM.lookup k m of
         Nothing -> Left "Key not found in memory database"
         Just v  -> Right v
+
+delete :: Db -> Text -> IO ()
+delete mvar k = atomically $ do
+    modifyTVar mvar (HM.delete k) >> return ()
 
 trav :: Db -> (Text -> (EncryptedPayload, [PublicKey]) -> IO Bool) -> IO ()
 trav mvar f = atomically (readTVar mvar) >>= loop . HM.toList

--- a/Constellation/Node/Storage/Sqlite.hs
+++ b/Constellation/Node/Storage/Sqlite.hs
@@ -77,11 +77,10 @@ load c k = do
         _        -> Left "load: More than one payload found"
 
 delete :: Connection -> Text -> IO ()
-delete c k = do
+delete c k = void $
     execute c
         "DELETE FROM payload WHERE payloadKey = ?"
         (Only k)
-    return ()
 
 trav :: Connection -> (Text -> (EncryptedPayload, [PublicKey]) -> IO Bool) -> IO ()
 trav c f = void $ fold_ c

--- a/Constellation/Node/Types.hs
+++ b/Constellation/Node/Types.hs
@@ -42,6 +42,7 @@ data Crypt = Crypt
 data Storage = Storage
     { savePayload     :: (EncryptedPayload, [PublicKey]) -> IO (Either String Text)
     , loadPayload     :: Text -> IO (Either String (EncryptedPayload, [PublicKey]))
+    , deletePayload   :: Text -> IO ()
     , traverseStorage :: (Text -> (EncryptedPayload, [PublicKey]) -> IO Bool) -> IO ()
     , closeStorage    :: IO ()
     }

--- a/constellation.cabal
+++ b/constellation.cabal
@@ -102,6 +102,7 @@ test-suite constellation-test
                        -- Constellation.Node.Storage.LevelDb.Test
                        Constellation.Node.Storage.Memory.Test
                        -- Constellation.Node.Storage.Sqlite.Test
+                       Constellation.Node.Storage.TestUtil
                        Constellation.Node.Types.Test
                        Constellation.TestUtil
                        Constellation.Util.AtExit.Test

--- a/test/Constellation/Node/Storage/BerkeleyDb/Test.hs
+++ b/test/Constellation/Node/Storage/BerkeleyDb/Test.hs
@@ -2,7 +2,55 @@
 module Constellation.Node.Storage.BerkeleyDb.Test where
 
 import ClassyPrelude
+import System.IO.Temp (withSystemTempDirectory)
 import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit ((@?=), testCaseSteps)
+import qualified Data.ByteString.Char8 as C
+
+import Constellation.Enclave.Key (newKeyPair)
+import Constellation.Enclave.Payload (encrypt)
+import Constellation.Enclave.Types (PublicKey(unPublicKey))
+import Constellation.Node.Storage.BerkeleyDb (berkeleyDbStorage)
+import Constellation.Node.Types (Storage(loadPayload, savePayload, deletePayload,
+                                         closeStorage))
 
 tests :: TestTree
-tests = testGroup "Node.Storage.BerkeleyDb" []
+tests = testGroup "Node.Storage.BerkeleyDb"
+    [ testBerkeleyDb
+    ]
+
+testBerkeleyDb :: TestTree
+testBerkeleyDb = testCaseSteps "delete" $ \step ->
+    withSystemTempDirectory "constellation-test-XXX" $ \tempDir-> do
+        step "Setting up BerkeleyDb instance"
+        storage <- berkeleyDbStorage tempDir
+
+        step "Saving payload"
+        (pub1, boxPriv1) <- newKeyPair
+        (pub2, _) <- newKeyPair
+        let boxPub1 = unPublicKey pub1
+        let boxPub2 = unPublicKey pub2
+        epl <- encrypt (C.pack "payload") boxPub1 boxPriv1 [boxPub2]
+        let kv = (epl, [pub2])
+        ek <- savePayload storage kv
+        key <- case ek of
+            Left err -> error $ "testBerkeleyDb: Saving of payload failed: " ++ err
+            Right key -> return key
+
+        step "Retrieving payload"
+        ret <- loadPayload storage key
+        case ret of
+            Left err -> error $ "testBerkeleyDb: Retrieval of payload failed: " ++ err
+            Right r -> r @?= kv
+
+        step "Deleting payload"
+        _ <- deletePayload storage key
+        
+        step "Verify deletion"
+        ver <- loadPayload storage key
+        case ver of
+            Left err -> err @?= "Key not found in BerkeleyDb payload.db"
+            Right _ -> error $ "testBerkeleyDb: Deletion of payload failed"
+        
+        step "Cleaning up"
+        closeStorage storage

--- a/test/Constellation/Node/Storage/BerkeleyDb/Test.hs
+++ b/test/Constellation/Node/Storage/BerkeleyDb/Test.hs
@@ -1,18 +1,14 @@
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE Strict #-}
 module Constellation.Node.Storage.BerkeleyDb.Test where
 
 import ClassyPrelude
 import System.IO.Temp (withSystemTempDirectory)
 import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.HUnit ((@?=), testCaseSteps)
-import qualified Data.ByteString.Char8 as C
+import Test.Tasty.HUnit (testCaseSteps)
 
-import Constellation.Enclave.Key (newKeyPair)
-import Constellation.Enclave.Payload (encrypt)
-import Constellation.Enclave.Types (PublicKey(unPublicKey))
 import Constellation.Node.Storage.BerkeleyDb (berkeleyDbStorage)
-import Constellation.Node.Types (Storage(loadPayload, savePayload, deletePayload,
-                                         closeStorage))
+import Constellation.Node.Storage.TestUtil (testStorage)
 
 tests :: TestTree
 tests = testGroup "Node.Storage.BerkeleyDb"
@@ -20,37 +16,8 @@ tests = testGroup "Node.Storage.BerkeleyDb"
     ]
 
 testBerkeleyDb :: TestTree
-testBerkeleyDb = testCaseSteps "delete" $ \step ->
+testBerkeleyDb = testCaseSteps "storage" $ \step ->
     withSystemTempDirectory "constellation-test-XXX" $ \tempDir-> do
         step "Setting up BerkeleyDb instance"
         storage <- berkeleyDbStorage tempDir
-
-        step "Saving payload"
-        (pub1, boxPriv1) <- newKeyPair
-        (pub2, _) <- newKeyPair
-        let boxPub1 = unPublicKey pub1
-        let boxPub2 = unPublicKey pub2
-        epl <- encrypt (C.pack "payload") boxPub1 boxPriv1 [boxPub2]
-        let kv = (epl, [pub2])
-        ek <- savePayload storage kv
-        key <- case ek of
-            Left err -> error $ "testBerkeleyDb: Saving of payload failed: " ++ err
-            Right key -> return key
-
-        step "Retrieving payload"
-        ret <- loadPayload storage key
-        case ret of
-            Left err -> error $ "testBerkeleyDb: Retrieval of payload failed: " ++ err
-            Right r -> r @?= kv
-
-        step "Deleting payload"
-        _ <- deletePayload storage key
-        
-        step "Verify deletion"
-        ver <- loadPayload storage key
-        case ver of
-            Left err -> err @?= "Key not found in BerkeleyDb payload.db"
-            Right _ -> error $ "testBerkeleyDb: Deletion of payload failed"
-        
-        step "Cleaning up"
-        closeStorage storage
+        testStorage storage "testBerkelyDb" step        

--- a/test/Constellation/Node/Storage/BerkeleyDb/Test.hs
+++ b/test/Constellation/Node/Storage/BerkeleyDb/Test.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE Strict #-}
+{-# LANGUAGE StrictData #-}
 module Constellation.Node.Storage.BerkeleyDb.Test where
 
 import ClassyPrelude

--- a/test/Constellation/Node/Storage/Memory/Test.hs
+++ b/test/Constellation/Node/Storage/Memory/Test.hs
@@ -2,7 +2,20 @@
 {-# LANGUAGE Strict #-}
 module Constellation.Node.Storage.Memory.Test where
 
+import ClassyPrelude
 import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCaseSteps)
+
+import Constellation.Node.Storage.Memory (memoryStorage)
+import Constellation.Node.Storage.TestUtil (testStorage)
 
 tests :: TestTree
-tests = testGroup "Node.Storage.Memory" []
+tests = testGroup "Node.Storage.Memory"
+    [ testMemory
+    ]
+
+testMemory :: TestTree
+testMemory = testCaseSteps "storage" $ \step -> do
+    step "Setting up memory instance"
+    storage <- memoryStorage
+    testStorage storage "testMemory" step        

--- a/test/Constellation/Node/Storage/TestUtil.hs
+++ b/test/Constellation/Node/Storage/TestUtil.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE Strict #-}
+{-# LANGUAGE StrictData #-}
 module Constellation.Node.Storage.TestUtil where
 
 import ClassyPrelude
 import Test.Tasty.HUnit ((@?), (@?=), Assertion)
-import qualified Data.ByteString.Char8 as C
+import qualified Data.ByteString.Char8 as BC
 
 import Constellation.Enclave.Key (newKeyPair)
 import Constellation.Enclave.Payload (encrypt)
@@ -19,7 +19,7 @@ testStorage storage testName = \step -> do
         (pub2, _) <- newKeyPair
         let boxPub1 = unPublicKey pub1
         let boxPub2 = unPublicKey pub2
-        epl <- encrypt (C.pack "payload") boxPub1 boxPriv1 [boxPub2]
+        epl <- encrypt (BC.pack "payload") boxPub1 boxPriv1 [boxPub2]
         let kv = (epl, [pub2])
         ek <- savePayload storage kv
         key <- case ek of

--- a/test/Constellation/Node/Storage/TestUtil.hs
+++ b/test/Constellation/Node/Storage/TestUtil.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE Strict #-}
+module Constellation.Node.Storage.TestUtil where
+
+import ClassyPrelude
+import Test.Tasty.HUnit ((@?), (@?=), Assertion)
+import qualified Data.ByteString.Char8 as C
+
+import Constellation.Enclave.Key (newKeyPair)
+import Constellation.Enclave.Payload (encrypt)
+import Constellation.Enclave.Types (PublicKey(unPublicKey))
+import Constellation.Node.Types (Storage(loadPayload, savePayload, deletePayload,
+                                         closeStorage))
+
+testStorage :: Storage -> String -> ((String -> IO ()) -> Assertion)
+testStorage storage testName = \step -> do
+        step "Saving payload"
+        (pub1, boxPriv1) <- newKeyPair
+        (pub2, _) <- newKeyPair
+        let boxPub1 = unPublicKey pub1
+        let boxPub2 = unPublicKey pub2
+        epl <- encrypt (C.pack "payload") boxPub1 boxPriv1 [boxPub2]
+        let kv = (epl, [pub2])
+        ek <- savePayload storage kv
+        key <- case ek of
+            Left err -> error $ testName ++ ": Saving of payload failed: " ++ err
+            Right key -> return key
+
+        step "Retrieving payload"
+        ret <- loadPayload storage key
+        case ret of
+            Left err -> error $ testName ++ ": Retrieval of payload failed: " ++ err
+            Right r -> r @?= kv
+
+        step "Deleting payload"
+        _ <- deletePayload storage key
+        
+        step "Verify deletion"
+        ver <- loadPayload storage key
+        case ver of
+            Left err -> "Key not found in " `isInfixOf` err @? testName ++ ": Key still present"
+            Right _ -> error $ testName ++ ": Deletion of payload failed"
+
+        step "Cleaning up"
+        closeStorage storage

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -18,6 +18,7 @@ import qualified Constellation.Node.Test as Node
 import qualified Constellation.Node.Api.Test as NodeApi
 import qualified Constellation.Node.Config.Test as NodeConfig
 import qualified Constellation.Node.Main.Test as NodeMain
+import qualified Constellation.Node.Storage.BerkeleyDb.Test as NodeStorageBerkeley
 -- import qualified Constellation.Node.Storage.LevelDb.Test as NodeStorageLevelDb
 import qualified Constellation.Node.Storage.Memory.Test as NodeStorageMemory
 import qualified Constellation.Node.Storage.Sqlite.Test as NodeStorageSqlite
@@ -43,6 +44,7 @@ tests = testGroup ""
     , NodeApi.tests
     , NodeConfig.tests
     , NodeMain.tests
+    , NodeStorageBerkeley.tests
     -- , NodeStorageLevelDb.tests
     , NodeStorageMemory.tests
     , NodeStorageSqlite.tests


### PR DESCRIPTION
This PR adds support for deleting entries in the Constellation payload store.
This is the first PR to address the following [request](https://github.com/jpmorganchase/constellation/issues/22) 

The API changes to support this method, and receive/sendRaw and will follow.