### PR TITLE
Node: Add --alwayssendto option specifying constant recipients, e.g. for backup

### DIFF
--- a/Constellation/Node.hs
+++ b/Constellation/Node.hs
@@ -29,21 +29,23 @@ newNode :: Crypt
         -> Storage
         -> Text
         -> [PublicKey]
+        -> [PublicKey]
         -> [Text]
         -> IO Node
-newNode crypt storage url rcpts parties = do
+newNode crypt storage url rcpts alwaysSendTo parties = do
     manager <- newManager tlsManagerSettings
         { managerConnCount = 100
         }
     return Node
-        { nodePi                = PartyInfo
+        { nodePi           = PartyInfo
               { piUrl     = url
               , piRcpts   = HM.fromList $ map (\pub -> (pub, url)) rcpts
               , piParties = HS.fromList (url : parties)
               }
-        , nodeCrypt             = crypt
-        , nodeStorage           = storage
-        , nodeManager           = manager
+        , nodeCrypt        = crypt
+        , nodeStorage      = storage
+        , nodeAlwaysSendTo = alwaysSendTo
+        , nodeManager      = manager
         }
 
 runNode :: TVar Node -> IO ()
@@ -125,7 +127,7 @@ sendPayload :: Node
             -> [PublicKey]
             -> IO [Either String Text]
 sendPayload node@Node{..} pl from rcpts = do
-    eenc <- encryptPayload nodeCrypt pl from rcpts
+    eenc <- encryptPayload nodeCrypt pl from (nodeAlwaysSendTo ++ rcpts)
     case eenc of
         Left err  -> return [Left err]
         Right epl -> do

--- a/Constellation/Node.hs
+++ b/Constellation/Node.hs
@@ -126,8 +126,9 @@ sendPayload :: Node
             -> PublicKey
             -> [PublicKey]
             -> IO [Either String Text]
-sendPayload node@Node{..} pl from rcpts = do
-    eenc <- encryptPayload nodeCrypt pl from (nodeAlwaysSendTo ++ rcpts)
+sendPayload node@Node{..} pl from initRcpts = do
+    let rcpts = nodeAlwaysSendTo ++ initRcpts
+    eenc <- encryptPayload nodeCrypt pl from rcpts
     case eenc of
         Left err  -> return [Left err]
         Right epl -> do

--- a/Constellation/Node/Main.hs
+++ b/Constellation/Node/Main.hs
@@ -23,7 +23,7 @@ import qualified Network.Wai.Handler.Warp as Warp
 
 import Constellation.Enclave
     (newEnclave', enclaveEncryptPayload, enclaveDecryptPayload)
-import Constellation.Enclave.Key (mustLoadKeyPairs)
+import Constellation.Enclave.Key (mustLoadKeyPairs, mustLoadPublicKeys)
 import Constellation.Node (newNode, runNode)
 import Constellation.Node.Storage.BerkeleyDb (berkeleyDbStorage)
 -- import Constellation.Node.Storage.Memory (memoryStorage)
@@ -81,11 +81,12 @@ run cfg@Config{..} = do
             { encryptPayload = enclaveEncryptPayload e
             , decryptPayload = enclaveDecryptPayload e
             }
+    ast <- mustLoadPublicKeys cfgAlwaysSendTo
     logf' "Initializing storage {}" [cfgStorage]
     storage <- berkeleyDbStorage cfgStorage
     -- storage <- memoryStorage
     nvar    <- newTVarIO =<<
-        newNode crypt storage cfgUrl (map fst ks) cfgOtherNodes
+        newNode crypt storage cfgUrl (map fst ks) ast cfgOtherNodes
     _ <- forkIO $ do
         let mwl = if null cfgIpWhitelist
                 then Nothing

--- a/Constellation/Node/Types.hs
+++ b/Constellation/Node/Types.hs
@@ -14,10 +14,11 @@ import Constellation.Enclave.Payload (EncryptedPayload)
 import Constellation.Enclave.Types (PublicKey)
 
 data Node = Node
-    { nodePi      :: PartyInfo
-    , nodeCrypt   :: Crypt
-    , nodeStorage :: Storage
-    , nodeManager :: Manager
+    { nodePi           :: PartyInfo
+    , nodeCrypt        :: Crypt
+    , nodeStorage      :: Storage
+    , nodeAlwaysSendTo :: [PublicKey]
+    , nodeManager      :: Manager
     }
 
 data PartyInfo = PartyInfo

--- a/sample.conf
+++ b/sample.conf
@@ -19,6 +19,10 @@ publickeys = ["foo.pub"]
 # The corresponding set of private keys
 privatekeys = ["foo.key"]
 
+# Optional comma-separated list of paths to public keys to add as recipients
+# for every transaction sent through this node, e.g. for backup purposes.
+# alwayssendto = []
+
 # Optional file containing the passwords to unlock the given privatekeys
 # (one password per line -- add an empty line if one key isn't locked.)
 # passwords = "passwords"

--- a/test/Constellation/TestUtil.hs
+++ b/test/Constellation/TestUtil.hs
@@ -36,7 +36,7 @@ setupTestNode d name = do
     port    <- getUnusedPort
     nvar    <- newTVarIO =<<
         newNode crypt storage (tformat "http://localhost:{}/" [port])
-        [pub1, pub2] []
+        [pub1, pub2] [] []
     return (nvar, port)
 
 link :: TVar Node -> TVar Node -> STM ()


### PR DESCRIPTION
Add --alwayssendto option to specify a list of constant recipients for outgoing payloads.

This is backwards-compatible with the 'archivalPublicKeyPath' option from v0.0.1, however there is no dependency on the private key (and 'archivalPrivateKeyPath' is ignored.) The alwayssendto public keys can be any keys that are advertised on the network (i.e. in some node's publickeys/privatekeys fields.)

This is primarily for backup purposes: Any Send request that yields an identifier guarantees all recipients have received the payload, and thus that the data has been backed up.