### PR TITLE
Node.Api: authenticateRequest renamed to authorizedRequest and made safer

### DIFF
--- a/Constellation/Node/Api.hs
+++ b/Constellation/Node/Api.hs
@@ -192,16 +192,19 @@ whitelisted Whitelist{..} (SockAddrInet6 _ _ addr _) = addr `Set.member` wlIPv6
 -- SockAddrUnix connects to the internal API which has a Nothing whitelist
 whitelisted _             _                          = False
 
-app :: Maybe Whitelist -> Bool -> TVar Node -> Wai.Application
-app (Just wl) allowSendReceive nvar req resp =
-    if whitelisted wl (Wai.remoteHost req)
-        then request allowSendReceive nvar req resp
-        else resp unauthorized
-app Nothing   allowSendReceive nvar req resp =
-    request allowSendReceive nvar req resp
+data ApiType = Internal
+             | External
 
-request :: Bool -> TVar Node -> Wai.Application
-request allowSendReceive nvar req resp = do
+app :: Maybe Whitelist -> ApiType -> TVar Node -> Wai.Application
+app (Just wl) apiType nvar req resp =
+    if whitelisted wl (Wai.remoteHost req)
+        then request apiType nvar req resp
+        else resp unauthorized
+app Nothing   apiType nvar req resp =
+    request apiType nvar req resp
+
+request :: ApiType -> TVar Node -> Wai.Application
+request apiType nvar req resp = do
     b <- Wai.lazyRequestBody req
     let h    = Wai.requestHeaders req
         path = Wai.pathInfo req
@@ -213,7 +216,7 @@ request allowSendReceive nvar req resp = do
                 , err
                 )
             resp badRequest
-        Right apiReq -> if authenticateRequest allowSendReceive apiReq
+        Right apiReq -> if authorizedRequest apiType apiReq
             then do
                 eapiRes <- performRequest nvar apiReq
                 case eapiRes of
@@ -257,12 +260,16 @@ parseRequest ["partyinfo"]  b _ = case decodeOrFail b of
 parseRequest ["upcheck"]    _ _ = Right ApiUpcheck
 parseRequest _              _ _ = Left "Not found"
 
-authenticateRequest :: Bool -> ApiRequest -> Bool
-authenticateRequest False (ApiSend _)       = False
-authenticateRequest False (ApiReceive _)    = False
-authenticateRequest False (ApiReceiveRaw _) = False
-authenticateRequest False (ApiDelete _)     = False
-authenticateRequest _     _                 = True
+authorizedRequest :: ApiType -> ApiRequest -> Bool
+authorizedRequest Internal (ApiSend _)       = True
+authorizedRequest Internal (ApiReceive _)    = True
+authorizedRequest Internal (ApiReceiveRaw _) = True
+authorizedRequest Internal (ApiDelete _)     = True
+authorizedRequest _        (ApiPush _)       = True
+authorizedRequest _        (ApiResend _)     = True
+authorizedRequest _        (ApiPartyInfo _)  = True
+authorizedRequest _        ApiUpcheck        = True
+authorizedRequest _        _                 = False
 
 performRequest :: TVar Node -> ApiRequest -> IO (Either String ApiResponse)
 performRequest nvar (ApiSend sreq)       = readTVarIO nvar >>= \node -> fmap ApiSendR       <$> send node sreq

--- a/Constellation/Node/Api.hs
+++ b/Constellation/Node/Api.hs
@@ -110,6 +110,12 @@ data ResendResponse = ResendIndividualRes EncryptedPayload
                     | ResentAll
                     deriving (Show)
 
+-- | The Private API allows sending, receiving/decrypting, deleting, and other
+-- sensitive operations, while the Public API only allows what other nodes need
+-- to exchange payloads.
+data ApiType = Public
+             | Private
+
 data ApiRequest = ApiSend Send
                 | ApiReceive Receive
                 | ApiReceiveRaw Receive
@@ -191,9 +197,6 @@ whitelisted Whitelist{..} (SockAddrInet _ addr)      = addr `Set.member` wlIPv4
 whitelisted Whitelist{..} (SockAddrInet6 _ _ addr _) = addr `Set.member` wlIPv6
 -- SockAddrUnix connects to the private API which has a Nothing whitelist
 whitelisted _             _                          = False
-
-data ApiType = Private
-             | Public
 
 app :: Maybe Whitelist -> ApiType -> TVar Node -> Wai.Application
 app (Just wl) apiType nvar req resp =

--- a/Constellation/Node/Api.hs
+++ b/Constellation/Node/Api.hs
@@ -189,11 +189,11 @@ whitelist strs = Whitelist
 whitelisted :: Whitelist -> SockAddr -> Bool
 whitelisted Whitelist{..} (SockAddrInet _ addr)      = addr `Set.member` wlIPv4
 whitelisted Whitelist{..} (SockAddrInet6 _ _ addr _) = addr `Set.member` wlIPv6
--- SockAddrUnix connects to the internal API which has a Nothing whitelist
+-- SockAddrUnix connects to the private API which has a Nothing whitelist
 whitelisted _             _                          = False
 
-data ApiType = Internal
-             | External
+data ApiType = Private
+             | Public
 
 app :: Maybe Whitelist -> ApiType -> TVar Node -> Wai.Application
 app (Just wl) apiType nvar req resp =
@@ -261,15 +261,15 @@ parseRequest ["upcheck"]    _ _ = Right ApiUpcheck
 parseRequest _              _ _ = Left "Not found"
 
 authorizedRequest :: ApiType -> ApiRequest -> Bool
-authorizedRequest Internal (ApiSend _)       = True
-authorizedRequest Internal (ApiReceive _)    = True
-authorizedRequest Internal (ApiReceiveRaw _) = True
-authorizedRequest Internal (ApiDelete _)     = True
-authorizedRequest _        (ApiPush _)       = True
-authorizedRequest _        (ApiResend _)     = True
-authorizedRequest _        (ApiPartyInfo _)  = True
-authorizedRequest _        ApiUpcheck        = True
-authorizedRequest _        _                 = False
+authorizedRequest Private (ApiSend _)       = True
+authorizedRequest Private (ApiReceive _)    = True
+authorizedRequest Private (ApiReceiveRaw _) = True
+authorizedRequest Private (ApiDelete _)     = True
+authorizedRequest _       (ApiPush _)       = True
+authorizedRequest _       (ApiResend _)     = True
+authorizedRequest _       (ApiPartyInfo _)  = True
+authorizedRequest _       ApiUpcheck        = True
+authorizedRequest _       _                 = False
 
 performRequest :: TVar Node -> ApiRequest -> IO (Either String ApiResponse)
 performRequest nvar (ApiSend sreq)       = readTVarIO nvar >>= \node -> fmap ApiSendR       <$> send node sreq

--- a/Constellation/Node/Config.hs
+++ b/Constellation/Node/Config.hs
@@ -97,10 +97,10 @@ options =
       "URL for this node (what's advertised to other nodes, e.g. https://constellation.mydomain.com/)"
 
     , Option [] ["port"] (OptArg (justDo setPort) "NUM")
-      "Port to listen on for the external API"
+      "Port to listen on for the public API"
 
     , Option [] ["socket"] (OptArg (justDo setSocket) "FILE")
-      "Path to IPC socket file to create for internal API access"
+      "Path to IPC socket file to create for private API access"
 
     , Option [] ["othernodes"] (OptArg (justDo setOtherNodes) "URL...")
       "Comma-separated list of other node URLs to connect to on startup (this list may be incomplete)"
@@ -118,7 +118,7 @@ options =
       "Storage path to pass to the storage engine"
 
     , Option [] ["ipwhitelist"] (OptArg (justDo setIpWhitelist) "IP...")
-      "Comma-separated list of IPv4 and IPv6 addresses that may connect to this node's external API"
+      "Comma-separated list of IPv4 and IPv6 addresses that may connect to this node's public API"
 
     , Option ['v'] ["verbosity"] (OptArg setVerbosity "NUM")
       "print more detailed information (optionally specify a number or add v's to increase verbosity)"

--- a/Constellation/Node/Main.hs
+++ b/Constellation/Node/Main.hs
@@ -90,11 +90,11 @@ run cfg@Config{..} = do
         let mwl = if null cfgIpWhitelist
                 then Nothing
                 else Just $ NodeApi.whitelist cfgIpWhitelist
-        logf' "External API listening on 0.0.0.0 port {} with whitelist: {}"
+        logf' "Public API listening on 0.0.0.0 port {} with whitelist: {}"
             ( cfgPort
             , Shown $ if isNothing mwl then ["Disabled"] else cfgIpWhitelist
             )
-        Warp.run cfgPort $ NodeApi.app mwl NodeApi.External nvar
+        Warp.run cfgPort $ NodeApi.app mwl NodeApi.Public nvar
     _ <- case cfgSocket of
         Just sockPath -> void $ forkIO $ do
             logf' "Internal API listening on {}" [sockPath]
@@ -103,7 +103,7 @@ run cfg@Config{..} = do
             bind sock $ SockAddrUnix sockPath
             listen sock maxListenQueue
             Warp.runSettingsSocket Warp.defaultSettings sock $
-                NodeApi.app Nothing NodeApi.Internal nvar
+                NodeApi.app Nothing NodeApi.Private nvar
             close sock
         Nothing       -> return ()
     registerAtExit $ do

--- a/Constellation/Node/Main.hs
+++ b/Constellation/Node/Main.hs
@@ -94,7 +94,7 @@ run cfg@Config{..} = do
             ( cfgPort
             , Shown $ if isNothing mwl then ["Disabled"] else cfgIpWhitelist
             )
-        Warp.run cfgPort $ NodeApi.app mwl False nvar
+        Warp.run cfgPort $ NodeApi.app mwl NodeApi.External nvar
     _ <- case cfgSocket of
         Just sockPath -> void $ forkIO $ do
             logf' "Internal API listening on {}" [sockPath]
@@ -103,7 +103,7 @@ run cfg@Config{..} = do
             bind sock $ SockAddrUnix sockPath
             listen sock maxListenQueue
             Warp.runSettingsSocket Warp.defaultSettings sock $
-                NodeApi.app Nothing True nvar
+                NodeApi.app Nothing NodeApi.Internal nvar
             close sock
         Nothing       -> return ()
     registerAtExit $ do

--- a/sample.conf
+++ b/sample.conf
@@ -26,7 +26,7 @@ privatekeys = ["foo.key"]
 # Where to store payloads and related information
 storage = "data"
 
-# Optional IP whitelist for the external API. If unspecified/empty,
+# Optional IP whitelist for the public API. If unspecified/empty,
 # connections from all sources will be allowed (but the private API remains
 # accessible only via the IPC socket above.) To allow connections from
 # localhost when a whitelist is defined, e.g. when running multiple

--- a/test/Constellation/Node/Api/Test.hs
+++ b/test/Constellation/Node/Api/Test.hs
@@ -61,9 +61,9 @@ testSendAndReceivePayload = testCaseSteps "sendAndReceivePayload" $ \step ->
         (node1Var, port1) <- setupTestNode d "node1"
         (node2Var, port2) <- setupTestNode d "node2"
         (node3Var, port3) <- setupTestNode d "node3"
-        tid1 <- forkIO $ Warp.run port1 $ NodeApi.app Nothing Internal node1Var
-        tid2 <- forkIO $ Warp.run port2 $ NodeApi.app Nothing Internal node2Var
-        tid3 <- forkIO $ Warp.run port3 $ NodeApi.app Nothing Internal node3Var
+        tid1 <- forkIO $ Warp.run port1 $ NodeApi.app Nothing Private node1Var
+        tid2 <- forkIO $ Warp.run port2 $ NodeApi.app Nothing Private node2Var
+        tid3 <- forkIO $ Warp.run port3 $ NodeApi.app Nothing Private node3Var
 
         step "Linking nodes"
         atomically $ do

--- a/test/Constellation/Node/Api/Test.hs
+++ b/test/Constellation/Node/Api/Test.hs
@@ -21,7 +21,7 @@ import qualified Network.Wai.Handler.Warp as Warp
 
 import Constellation.Enclave.Types (PublicKey, mkPublicKey)
 import Constellation.Node (nodeRefresh)
-import Constellation.Node.Api (Send(..))
+import Constellation.Node.Api (ApiType(..), Send(..))
 import Constellation.Node.Types (Node(nodeStorage), Storage(closeStorage))
 import Constellation.Util.ByteString (mustB64TextDecodeBs)
 import qualified Constellation.Node.Api as NodeApi
@@ -61,9 +61,9 @@ testSendAndReceivePayload = testCaseSteps "sendAndReceivePayload" $ \step ->
         (node1Var, port1) <- setupTestNode d "node1"
         (node2Var, port2) <- setupTestNode d "node2"
         (node3Var, port3) <- setupTestNode d "node3"
-        tid1 <- forkIO $ Warp.run port1 $ NodeApi.app Nothing True node1Var
-        tid2 <- forkIO $ Warp.run port2 $ NodeApi.app Nothing True node2Var
-        tid3 <- forkIO $ Warp.run port3 $ NodeApi.app Nothing True node3Var
+        tid1 <- forkIO $ Warp.run port1 $ NodeApi.app Nothing Internal node1Var
+        tid2 <- forkIO $ Warp.run port2 $ NodeApi.app Nothing Internal node2Var
+        tid3 <- forkIO $ Warp.run port3 $ NodeApi.app Nothing Internal node3Var
 
         step "Linking nodes"
         atomically $ do


### PR DESCRIPTION
The current authenticateRequest lists out which endpoints are blocked, and allows everything else. In this modified authorizedRequest, anything not explicitly authorized is blocked. The allowSendReceive bool has been changed to the clearer `ApiType = Private | Public` as well.

This means that there is a much smaller chance of accidentally leaving out a new, internal-only API endpoint, but also that every endpoint must be listed.

This addresses https://github.com/jpmorganchase/constellation/issues/27