### PR TITLE
Node/Config: Add --generatekeys option

### DIFF
--- a/Constellation/Node/Config.hs
+++ b/Constellation/Node/Config.hs
@@ -23,32 +23,34 @@ import Constellation.Util.Exception (trys)
 import Constellation.Util.String (trimBoth)
 
 data Config = Config
-    { cfgUrl             :: Text
-    , cfgPort            :: Int
-    , cfgSocket          :: Maybe FilePath
-    , cfgOtherNodes      :: [Text]
-    , cfgPublicKeys      :: [FilePath]
-    , cfgPrivateKeys     :: [FilePath]
-    , cfgPasswords       :: Maybe FilePath
-    , cfgStorage         :: String
-    , cfgIpWhitelist     :: [String]
-    , cfgJustShowVersion :: Bool
-    , cfgVerbosity       :: Int
+    { cfgUrl              :: Text
+    , cfgPort             :: Int
+    , cfgSocket           :: Maybe FilePath
+    , cfgOtherNodes       :: [Text]
+    , cfgPublicKeys       :: [FilePath]
+    , cfgPrivateKeys      :: [FilePath]
+    , cfgPasswords        :: Maybe FilePath
+    , cfgStorage          :: String
+    , cfgIpWhitelist      :: [String]
+    , cfgJustShowVersion  :: Bool
+    , cfgJustGenerateKeys :: [String]
+    , cfgVerbosity        :: Int
     } deriving Show
 
 instance Default Config where
     def = Config
-        { cfgUrl             = ""
-        , cfgPort            = 0
-        , cfgSocket          = Nothing
-        , cfgOtherNodes      = []
-        , cfgPublicKeys      = []
-        , cfgPrivateKeys     = []
-        , cfgPasswords       = Nothing
-        , cfgStorage         = "storage"
-        , cfgIpWhitelist     = []
-        , cfgJustShowVersion = False
-        , cfgVerbosity       = defaultVerbosity
+        { cfgUrl              = ""
+        , cfgPort             = 0
+        , cfgSocket           = Nothing
+        , cfgOtherNodes       = []
+        , cfgPublicKeys       = []
+        , cfgPrivateKeys      = []
+        , cfgPasswords        = Nothing
+        , cfgStorage          = "storage"
+        , cfgIpWhitelist      = []
+        , cfgJustShowVersion  = False
+        , cfgJustGenerateKeys = []
+        , cfgVerbosity        = defaultVerbosity
         }
 
 instance FromJSON Config where
@@ -85,6 +87,7 @@ instance FromJSON Config where
             <*> v .:? "storage"     .!= "storage"
             <*> v .:? "ipwhitelist" .!= []
             <*> pure False
+            <*> pure []
             <*> v .:? "verbosity"   .!= 1
     parseJSON _          = mzero
 
@@ -124,7 +127,10 @@ options =
       "print more detailed information (optionally specify a number or add v's to increase verbosity)"
 
     , Option ['V', '?'] ["version"] (NoArg setVersion)
-      "output current version information and exit"
+      "output current version information, then exit"
+
+    , Option [] ["generatekeys"] (OptArg (justDo setGenerateKeys) "NAME...")
+      "comma-separated list of key pair names to generate, then exit"
     ]
 
 justDo :: (String -> Config -> Config) -> Maybe String -> Config -> Config
@@ -168,6 +174,9 @@ setVerbosity Nothing  c = c { cfgVerbosity = 2 }  -- '-v' given, increase to inf
 
 setVersion :: Config -> Config
 setVersion c = c { cfgJustShowVersion = True }
+
+setGenerateKeys :: String -> Config -> Config
+setGenerateKeys s c = c { cfgJustGenerateKeys = map trimBoth (splitOn "," s) }
 
 extractConfig :: [String] -> IO (Config, [String])
 extractConfig []   = errorOut "No arguments given"

--- a/Constellation/Node/Main.hs
+++ b/Constellation/Node/Main.hs
@@ -24,6 +24,7 @@ import qualified Network.Wai.Handler.Warp as Warp
 import Constellation.Enclave
     (newEnclave', enclaveEncryptPayload, enclaveDecryptPayload)
 import Constellation.Enclave.Key (mustLoadKeyPairs)
+import Constellation.Enclave.Keygen.Main (generateKeyPair)
 import Constellation.Node (newNode, runNode)
 import Constellation.Node.Storage.BerkeleyDb (berkeleyDbStorage)
 -- import Constellation.Node.Storage.Memory (memoryStorage)
@@ -46,7 +47,9 @@ defaultMain = do
     (cfg, _) <- extractConfig args
     if cfgJustShowVersion cfg
         then putStrLn ("Constellation Node " ++ version)
-        else withStderrLogging $ run cfg
+        else case cfgJustGenerateKeys cfg of
+                 [] -> withStderrLogging $ run cfg
+                 ks -> mapM_ generateKeyPair ks
 
 run :: Config -> IO ()
 run cfg@Config{..} = do

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ Constellation binaries for most major platforms can be downloaded [here](https:/
 ## Generating keys
 
   1. To generate a key pair "node", run `constellation-node --generatekeys=node`
-     or `constellation-enclave-keygen node`
 
   If you choose to lock the keys with a password, they will be encrypted using
   a master key derived from the password using Argon2i. This is designed to be

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Constellation binaries for most major platforms can be downloaded [here](https:/
 
 ## Generating keys
 
-  1. To generate a key pair "node", run `constellation-enclave-keygen node`
+  1. To generate a key pair "node", run `constellation-node --generatekeys=node`
+     or `constellation-enclave-keygen node`
 
   If you choose to lock the keys with a password, they will be encrypted using
   a master key derived from the password using Argon2i. This is designed to be

--- a/constellation.cabal
+++ b/constellation.cabal
@@ -161,14 +161,14 @@ executable constellation-node
 --                      , constellation
 --   default-language:    Haskell2010
 
-executable constellation-enclave-keygen
-  hs-source-dirs:      bin
-  main-is:             EnclaveKeygen.hs
-  ghc-options:         -threaded
-                       -Wall
-  build-depends:       base
-                     , constellation
-  default-language:    Haskell2010
+-- executable constellation-enclave-keygen
+--   hs-source-dirs:      bin
+--   main-is:             EnclaveKeygen.hs
+--   ghc-options:         -threaded
+--                        -Wall
+--   build-depends:       base
+--                      , constellation
+--   default-language:    Haskell2010
 
 -- executable constellation-configure
 --   hs-source-dirs:      bin


### PR DESCRIPTION
This removes the need to download and run `constellation-enclave-keygen` to use Constellation.