### PR TITLE
Expose key encoding functions

### DIFF
--- a/Constellation/Enclave/Key.hs
+++ b/Constellation/Enclave/Key.hs
@@ -11,17 +11,33 @@ import Control.Monad.Trans.Either (EitherT(EitherT), runEitherT)
 import qualified Crypto.Saltine.Class as S
 import qualified Crypto.Saltine.Core.Box as Box
 import qualified Data.Aeson as AE
+import qualified Data.ByteString.Base64.Lazy as B64L
+import qualified Data.ByteString.Lazy as BL
 import qualified Data.Text as T
 
-import Constellation.Enclave.Types (PublicKey(PublicKey), mkPublicKey)
+import Constellation.Enclave.Types
+    (PublicKey(PublicKey, unPublicKey), mkPublicKey)
 import Constellation.Util.ByteString (b64TextDecodeBs)
 import Constellation.Util.Either (fromShowRight, flattenEithers, maybeToEitherT)
-import Constellation.Util.Lockable (unlock, promptingUnlock)
+import Constellation.Util.Lockable
+    (Lockable(Unlocked), lock, promptingUnlock, unlock)
 
 newKeyPair :: IO (PublicKey, Box.SecretKey)
 newKeyPair = do
     (priv, pub) <- Box.newKeypair
     return (PublicKey pub, priv)
+
+b64EncodePublicKey :: PublicKey -> BL.ByteString
+b64EncodePublicKey = B64L.encode . BL.fromStrict . S.encode . unPublicKey
+
+-- | Optionally takes a password to lock the private key.
+jsonEncodePrivateKey :: Maybe String -> Box.SecretKey -> IO BL.ByteString
+jsonEncodePrivateKey mpwd priv = AE.encode <$> mkLockable
+  where
+    mkLockable = case mpwd of
+        Nothing  -> return $ Unlocked (S.encode priv)
+        Just ""  -> return $ Unlocked (S.encode priv)
+        Just pwd -> lock pwd (S.encode priv)
 
 loadKeyPair :: (FilePath, FilePath, Maybe String)
             -> IO (Either String (PublicKey, Box.SecretKey))

--- a/Constellation/Enclave/Key.hs
+++ b/Constellation/Enclave/Key.hs
@@ -33,7 +33,7 @@ loadKeyPair (pubPath, privPath, mpwd) = runEitherT $ do
         Just pwd -> return $ unlock pwd locked
         Nothing  -> promptingUnlock locked
     liftIO $ putStrLn $ "Unlocked " ++ privPath
-    (pub,) <$> maybeToEitherT "Failed to S.encode privBs" (S.decode privBs)
+    (pub,) <$> maybeToEitherT "Failed to S.decode privBs" (S.decode privBs)
 
 loadPublicKey :: FilePath -> IO (Either String PublicKey)
 loadPublicKey pubPath = runEitherT $ do

--- a/Constellation/Enclave/Keygen/Main.hs
+++ b/Constellation/Enclave/Keygen/Main.hs
@@ -8,14 +8,10 @@ import ClassyPrelude hiding (getArgs, writeFile)
 import System.Console.Haskeline (runInputT, defaultSettings, getPassword)
 import System.Environment (getArgs, getProgName)
 import Text.Printf (printf)
-import qualified Crypto.Saltine.Class as S
-import qualified Data.Aeson as AE
-import qualified Data.ByteString.Base64.Lazy as B64L
 import qualified Data.ByteString.Lazy as BL
 
-import Constellation.Enclave.Key (newKeyPair)
-import Constellation.Enclave.Types (PublicKey(unPublicKey))
-import Constellation.Util.Lockable (Lockable(Unlocked), lock)
+import Constellation.Enclave.Key
+    (newKeyPair, b64EncodePublicKey, jsonEncodePrivateKey)
 import Constellation.Util.Text (tformat)
 
 defaultMain :: IO ()
@@ -28,13 +24,9 @@ generateKeyPair name = do
     mpwd <- runInputT defaultSettings $
         getPassword (Just '*') (printf "Lock key pair %s with password [none]: " name)
     (pub, priv) <- newKeyPair
-    BL.writeFile (name ++ ".pub") $ B64L.encode $ BL.fromStrict $ S.encode $
-        unPublicKey pub
-    k <- case mpwd of
-        Nothing  -> return $ Unlocked (S.encode priv)
-        Just ""  -> return $ Unlocked (S.encode priv)
-        Just pwd -> lock pwd (S.encode priv)
-    BL.writeFile (name ++ ".key") $ AE.encode k
+    BL.writeFile (name ++ ".pub") $ b64EncodePublicKey pub
+    json <- jsonEncodePrivateKey mpwd priv
+    BL.writeFile (name ++ ".key") json
 
 usage :: IO ()
 usage = getProgName >>= \progName ->


### PR DESCRIPTION
I extracted two functions, `b64EncodePublicKey` and `jsonEncodePrivateKey`, that make it easier to do key generation using constellation as a library (vs executable). Let me know if you'd like me to change anything.