### PR TITLE
Node.Storage.*: Add sqlite, leveldb, and memory storage engines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
       folder.
     - `--storage=leveldb:path`: `leveldb` storage engine using the `path`
       folder.
-    - `--storage=memory`: `memory` storage engine.
+    - `--storage=memory`: non-persistent `memory` storage engine.
     - `--storage=sqlite:path`: `sqlite` storage engine using the `path`
       folder.
     - `--storage=path`: Default storage engine (`bdb`) using the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,24 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   The `dir` storage engine uses Base32-encoded filenames to ensure
   compatibility with most file systems.
 
+- (Experimental) A 'sqlite' storage engine. See related discussion at
+  https://github.com/jpmorganchase/constellation/issues/37
+
+- (Experimental) A 'leveldb' storage engine. See related discussion at
+  https://github.com/jpmorganchase/constellation/issues/37
+
+- A non-persistent 'memory' storage engine.
+
 - Ability to choose a storage engine in configs and on the command
   line:
+    - `--storage=bdb:path`: `bdb` storage engine using the `path`
+      folder.
     - `--storage=dir:path`: `dir` storage engine using the `path`
       folder.
-    - `--storage=bdb:path`: `bdb` storage engine using the `path`
+    - `--storage=leveldb:path`: `leveldb` storage engine using the `path`
+      folder.
+    - `--storage=memory`: `memory` storage engine.
+    - `--storage=sqlite:path`: `sqlite` storage engine using the `path`
       folder.
     - `--storage=path`: Default storage engine (`bdb`) using the
       `path` folder.

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Agents (MTAs) exchanging PGP-encrypted emails.
 ### Prerequisites
 
   1. Install supporting libraries:
-    - Ubuntu: `apt-get install libdb-dev libsodium-dev zlib1g-dev libtinfo-dev`
-    - Red Hat: `dnf install libdb-devel libsodium-devel zlib-devel ncurses-devel`
-    - MacOS: `brew install berkeley-db libsodium`
+    - Ubuntu: `apt-get install libdb-dev libleveldb-dev libsodium-dev zlib1g-dev libtinfo-dev`
+    - Red Hat: `dnf install libdb-devel leveldb-devel libsodium-devel zlib-devel ncurses-devel`
+    - MacOS: `brew install berkeley-db leveldb libsodium`
 
 ### Downloading precompiled binaries
 

--- a/constellation.cabal
+++ b/constellation.cabal
@@ -28,9 +28,9 @@ library
                        Constellation.Node.Main
                        Constellation.Node.Storage.BerkeleyDb
                        Constellation.Node.Storage.Directory
-                       -- Constellation.Node.Storage.LevelDb
+                       Constellation.Node.Storage.LevelDb
                        Constellation.Node.Storage.Memory
-                       -- Constellation.Node.Storage.Sqlite
+                       Constellation.Node.Storage.Sqlite
                        Constellation.Node.Types
                        Constellation.Util.AtExit
                        Constellation.Util.ByteString
@@ -66,17 +66,17 @@ library
                      , http-types
                      , iproute >= 1.7
                      -- , lens
-                     -- , leveldb-haskell
+                     , leveldb-haskell >= 0.6.5
                      , logging >= 3.0.4
                      , memory >= 0.13
                      , network >= 2.6.3.1
                      , network-uri >= 2.6.1.0
                      , random >= 1.1
                      , raw-strings-qq >= 1.1
-                     -- , resource-pool
+                     , resource-pool >= 0.2.3.2
                      , saltine >= 0.0.0.4
                      , split >= 0.2.3.1
-                     -- , sqlite-simple
+                     , sqlite-simple >= 0.4.13.0
                      , text >= 1.2.2.1
                      , text-format >= 0.3.1.1
                      , unordered-containers >= 0.2.7.1
@@ -99,10 +99,10 @@ test-suite constellation-test
                        Constellation.Node.Config.Test
                        Constellation.Node.Main.Test
                        Constellation.Node.Storage.BerkeleyDb.Test
-                       -- Constellation.Node.Storage.LevelDb.Test
+                       Constellation.Node.Storage.LevelDb.Test
                        Constellation.Node.Storage.Directory.Test
                        Constellation.Node.Storage.Memory.Test
-                       -- Constellation.Node.Storage.Sqlite.Test
+                       Constellation.Node.Storage.Sqlite.Test
                        Constellation.Node.Storage.TestUtil
                        Constellation.Node.Types.Test
                        Constellation.TestUtil

--- a/test/Constellation/Node/Storage/BerkeleyDb/Test.hs
+++ b/test/Constellation/Node/Storage/BerkeleyDb/Test.hs
@@ -20,4 +20,4 @@ testBerkeleyDb = testCaseSteps "storage" $ \step ->
     withSystemTempDirectory "constellation-test-XXX" $ \tempDir-> do
         step "Setting up BerkeleyDb instance"
         storage <- berkeleyDbStorage tempDir
-        testStorage storage "testBerkelyDb" step        
+        testStorage storage "testBerkeleyDb" step

--- a/test/Constellation/Node/Storage/Directory/Test.hs
+++ b/test/Constellation/Node/Storage/Directory/Test.hs
@@ -17,7 +17,7 @@ tests = testGroup "Node.Storage.Directory"
 
 testDirectory :: TestTree
 testDirectory = testCaseSteps "storage" $ \step ->
-    withSystemTempDirectory "constellation-test-storage-directory-XXX" $ \tempDir -> do
-        step "Setting up directory instance"
+    withSystemTempDirectory "constellation-test-XXX" $ \tempDir -> do
+        step "Setting up Directory instance"
         storage <- directoryStorage tempDir
         testStorage storage "testDirectory" step        

--- a/test/Constellation/Node/Storage/LevelDb/Test.hs
+++ b/test/Constellation/Node/Storage/LevelDb/Test.hs
@@ -3,6 +3,7 @@
 module Constellation.Node.Storage.LevelDb.Test where
 
 import ClassyPrelude
+import System.IO.Temp (withSystemTempDirectory)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (testCaseSteps)
 
@@ -16,6 +17,7 @@ tests = testGroup "Node.Storage.LevelDb"
 
 testLevelDb :: TestTree
 testLevelDb = testCaseSteps "storage" $ \step -> do
-    step "Setting up LevelDb instance"
-    storage <- levelDbStorage "constellation-test-leveldb"
-    testStorage storage "testLevelDb" step
+    withSystemTempDirectory "constellation-test-XXX" $ \tempDir-> do
+        step "Setting up LevelDB instance"
+        storage <- levelDbStorage tempDir
+        testStorage storage "testLevelDb" step

--- a/test/Constellation/Node/Storage/Memory/Test.hs
+++ b/test/Constellation/Node/Storage/Memory/Test.hs
@@ -16,6 +16,6 @@ tests = testGroup "Node.Storage.Memory"
 
 testMemory :: TestTree
 testMemory = testCaseSteps "storage" $ \step -> do
-    step "Setting up memory instance"
+    step "Setting up Memory instance"
     storage <- memoryStorage
     testStorage storage "testMemory" step        

--- a/test/Constellation/Node/Storage/Sqlite/Test.hs
+++ b/test/Constellation/Node/Storage/Sqlite/Test.hs
@@ -3,6 +3,7 @@
 module Constellation.Node.Storage.Sqlite.Test where
 
 import ClassyPrelude
+import System.IO.Temp (withSystemTempDirectory)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (testCaseSteps)
 
@@ -16,6 +17,7 @@ tests = testGroup "Node.Storage.Sqlite"
 
 testSqlite :: TestTree
 testSqlite = testCaseSteps "storage" $ \step -> do
-    step "Setting up sqlite instance"
-    storage <- sqliteStorage "constellation-test-sqlite"
-    testStorage storage "testSqlite" step
+    withSystemTempDirectory "constellation-test-XXX" $ \tempDir-> do
+        step "Setting up SQLite instance"
+        storage <- sqliteStorage (tempDir </> "test.db")
+        testStorage storage "testSqlite" step

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -20,9 +20,9 @@ import qualified Constellation.Node.Config.Test as NodeConfig
 import qualified Constellation.Node.Main.Test as NodeMain
 import qualified Constellation.Node.Storage.BerkeleyDb.Test as NodeStorageBerkeley
 import qualified Constellation.Node.Storage.Directory.Test as NodeStorageDirectory
--- import qualified Constellation.Node.Storage.LevelDb.Test as NodeStorageLevelDb
+import qualified Constellation.Node.Storage.LevelDb.Test as NodeStorageLevelDb
 import qualified Constellation.Node.Storage.Memory.Test as NodeStorageMemory
--- import qualified Constellation.Node.Storage.Sqlite.Test as NodeStorageSqlite
+import qualified Constellation.Node.Storage.Sqlite.Test as NodeStorageSqlite
 import qualified Constellation.Node.Types.Test as NodeTypes
 import qualified Constellation.Util.AtExit.Test as UtilAtExit
 import qualified Constellation.Util.ByteString.Test as UtilByteString
@@ -46,9 +46,9 @@ tests = testGroup ""
     , NodeMain.tests
     , NodeStorageBerkeley.tests
     , NodeStorageDirectory.tests
-    -- , NodeStorageLevelDb.tests
+    , NodeStorageLevelDb.tests
     , NodeStorageMemory.tests
-    -- , NodeStorageSqlite.tests
+    , NodeStorageSqlite.tests
     , NodeTypes.tests
     , UtilAtExit.tests
     , UtilByteString.tests


### PR DESCRIPTION
This adds the `sqlite`, `leveldb`, and `memory` storage engines. The first two are experimental pending conclusion of the discussion in https://github.com/jpmorganchase/constellation/issues/37

A benchmark suite comparing the available storage engines will follow in a separate PR. 