### PR TITLE
Node: Allow sending to "self"/no recipients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     - `--storage=path`: Default storage engine (`bdb`) using the
       `path` folder.
 
+- The 'to' field of Send requests may now be empty. When there are
+  no recipients, the payload will be encrypted using a throwaway
+  public key, and the encrypted payload will not be sent to any
+  external nodes.
+
 ## [0.1.0] - 2017-06-06
 
 This release includes changes to the configuration file

--- a/Constellation/Node.hs
+++ b/Constellation/Node.hs
@@ -129,11 +129,11 @@ sendPayload :: Node
             -> PublicKey
             -> [PublicKey]
             -> IO [Either String Text]
-sendPayload node@Node{..} pl from initRcpts = do
-    let (onlySelf, rcpts) = if null rcptsWithAst
+sendPayload node@Node{..} pl from givenRcpts = do
+    let (onlySelf, rcpts) = if null allRcpts
             then (True, [nodeSelfPub])
-            else (False, rcptsWithAst)
-        rcptsWithAst      = nodeAlwaysSendTo ++ initRcpts
+            else (False, allRcpts)
+        allRcpts          = nodeAlwaysSendTo ++ givenRcpts
     eenc <- encryptPayload nodeCrypt pl from rcpts
     case eenc of
         Left err  -> return [Left err]

--- a/Constellation/Node/Main.hs
+++ b/Constellation/Node/Main.hs
@@ -23,7 +23,8 @@ import qualified Network.Wai.Handler.Warp as Warp
 
 import Constellation.Enclave
     (newEnclave', enclaveEncryptPayload, enclaveDecryptPayload)
-import Constellation.Enclave.Key (mustLoadKeyPairs, mustLoadPublicKeys)
+import Constellation.Enclave.Key
+    (newKeyPair, mustLoadKeyPairs, mustLoadPublicKeys)
 import Constellation.Enclave.Keygen.Main (generateKeyPair)
 import Constellation.Node (newNode, runNode)
 import Constellation.Node.Storage.BerkeleyDb (berkeleyDbStorage)
@@ -87,7 +88,9 @@ run cfg@Config{..} = do
             { encryptPayload = enclaveEncryptPayload e
             , decryptPayload = enclaveDecryptPayload e
             }
-    ast <- mustLoadPublicKeys cfgAlwaysSendTo
+    ast     <- mustLoadPublicKeys cfgAlwaysSendTo
+    selfPub <- fst <$> newKeyPair
+    logf' "Throwaway public key for self-sending: {}" [show selfPub]
     logf' "Initializing storage {}" [cfgStorage]
     let experimentalStorageCaveat s = warnf "The {} storage engine is experimental. It may be removed or changed at any time. Please see the discussion at https://github.com/jpmorganchase/constellation/issues/37" [s :: Text]
     storage <- case break (== ':') cfgStorage of
@@ -100,7 +103,7 @@ run cfg@Config{..} = do
             >> sqliteStorage path
         _                     -> berkeleyDbStorage cfgStorage  -- Default
     nvar    <- newTVarIO =<<
-        newNode crypt storage cfgUrl (map fst ks) ast cfgOtherNodes
+        newNode crypt storage cfgUrl (map fst ks) ast selfPub cfgOtherNodes
     _ <- forkIO $ do
         let mwl = if null cfgIpWhitelist
                 then Nothing

--- a/Constellation/Node/Main.hs
+++ b/Constellation/Node/Main.hs
@@ -88,8 +88,8 @@ run cfg@Config{..} = do
             { encryptPayload = enclaveEncryptPayload e
             , decryptPayload = enclaveDecryptPayload e
             }
-    ast     <- mustLoadPublicKeys cfgAlwaysSendTo
-    selfPub <- fst <$> newKeyPair
+    ast          <- mustLoadPublicKeys cfgAlwaysSendTo
+    (selfPub, _) <- newKeyPair
     logf' "Throwaway public key for self-sending: {}" [show selfPub]
     logf' "Initializing storage {}" [cfgStorage]
     let experimentalStorageCaveat s = warnf "The {} storage engine is experimental. It may be removed or changed at any time. Please see the discussion at https://github.com/jpmorganchase/constellation/issues/37" [s :: Text]

--- a/Constellation/Node/Types.hs
+++ b/Constellation/Node/Types.hs
@@ -18,6 +18,7 @@ data Node = Node
     , nodeCrypt        :: Crypt
     , nodeStorage      :: Storage
     , nodeAlwaysSendTo :: [PublicKey]
+    , nodeSelfPub      :: PublicKey
     , nodeManager      :: Manager
     }
 

--- a/test/Constellation/TestUtil.hs
+++ b/test/Constellation/TestUtil.hs
@@ -27,6 +27,7 @@ setupTestNode :: FilePath -> String -> IO (TVar Node, Int)
 setupTestNode d name = do
     kp1@(pub1, _) <- newKeyPair
     kp2@(pub2, _) <- newKeyPair
+    selfPub       <- fst <$> newKeyPair
     e             <- newEnclave' [kp1, kp2]
     let crypt = Crypt
             { encryptPayload = enclaveEncryptPayload e
@@ -36,7 +37,7 @@ setupTestNode d name = do
     port    <- getUnusedPort
     nvar    <- newTVarIO =<<
         newNode crypt storage (tformat "http://localhost:{}/" [port])
-        [pub1, pub2] [] []
+        [pub1, pub2] [] selfPub []
     return (nvar, port)
 
 link :: TVar Node -> TVar Node -> STM ()

--- a/test/Constellation/TestUtil.hs
+++ b/test/Constellation/TestUtil.hs
@@ -27,7 +27,7 @@ setupTestNode :: FilePath -> String -> IO (TVar Node, Int)
 setupTestNode d name = do
     kp1@(pub1, _) <- newKeyPair
     kp2@(pub2, _) <- newKeyPair
-    selfPub       <- fst <$> newKeyPair
+    (selfPub, _)  <- newKeyPair
     e             <- newEnclave' [kp1, kp2]
     let crypt = Crypt
             { encryptPayload = enclaveEncryptPayload e


### PR DESCRIPTION
Uses a throwaway public key generated at runtime to keep using NaCl box