### PR TITLE
Node.Api: Raw send/receive renames and HTTP utility function changes

### DIFF
--- a/Constellation/Util/Http.hs
+++ b/Constellation/Util/Http.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE StrictData #-}
+module Constellation.Util.Http where
+
+import ClassyPrelude
+import Network.HTTP.Types (HeaderName, RequestHeaders)
+import qualified Data.ByteString.Char8 as BC
+
+getHeaderCommaValues :: HeaderName -> RequestHeaders -> [ByteString]
+getHeaderCommaValues hname h =
+    concatMap (BC.split ',') (getHeaderValues hname h)
+
+getHeaderValues :: HeaderName -> RequestHeaders -> [ByteString]
+getHeaderValues hname h = [v | (k, v) <- h, k == hname]

--- a/constellation.cabal
+++ b/constellation.cabal
@@ -36,6 +36,7 @@ library
                        Constellation.Util.ByteString
                        Constellation.Util.Either
                        Constellation.Util.Exception
+                       Constellation.Util.Http
                        Constellation.Util.Lockable
                        Constellation.Util.Logging
                        Constellation.Util.Network
@@ -110,6 +111,7 @@ test-suite constellation-test
                        Constellation.Util.ByteString.Test
                        Constellation.Util.Either.Test
                        Constellation.Util.Exception.Test
+                       Constellation.Util.Http.Test
                        Constellation.Util.Lockable.Test
                        Constellation.Util.Logging.Test
                        Constellation.Util.Network.Test

--- a/test/Constellation/Util/Http/Test.hs
+++ b/test/Constellation/Util/Http/Test.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE StrictData #-}
+module Constellation.Util.Http.Test where
+
+import ClassyPrelude
+import Network.HTTP.Types (Header, RequestHeaders)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit ((@?=), testCase)
+import qualified Data.ByteString.Char8 as BC
+
+import Constellation.Util.Http (getHeaderValues, getHeaderCommaValues)
+
+tests :: TestTree
+tests = testGroup "Util.Http"
+    [ testGetHeaderValues
+    , testGetHeaderValuesInvalid
+    , testGetHeaderCommaValues
+    ]
+
+h1 :: Header
+h1 = ("h1", BC.pack "value1")
+
+h2 :: Header
+h2 = ("h2", BC.pack "value2,value3")
+
+h2Plus :: Header
+h2Plus = ("h2", BC.pack "value4")
+
+hs :: RequestHeaders
+hs = [h1, h2, h2Plus]
+
+testGetHeaderValues :: TestTree
+testGetHeaderValues = testCase "getHeaderValues" $
+    getHeaderValues "h1" hs @?= [snd h1]
+
+testGetHeaderValuesInvalid :: TestTree
+testGetHeaderValuesInvalid = testCase "getHeaderValuesInvalid" $
+    getHeaderValues "invalid" hs @?= []
+
+testGetHeaderCommaValues :: TestTree
+testGetHeaderCommaValues = testCase "getHeaderCommaValues" $
+    getHeaderCommaValues "h2" hs @?= ["value2", "value3", "value4"]

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -28,6 +28,7 @@ import qualified Constellation.Util.AtExit.Test as UtilAtExit
 import qualified Constellation.Util.ByteString.Test as UtilByteString
 import qualified Constellation.Util.Either.Test as UtilEither
 import qualified Constellation.Util.Exception.Test as UtilException
+import qualified Constellation.Util.Http.Test as UtilHttp
 import qualified Constellation.Util.Lockable.Test as UtilLockable
 import qualified Constellation.Util.Network.Test as UtilNetwork
 import qualified Constellation.Util.String.Test as UtilString
@@ -54,6 +55,7 @@ tests = testGroup ""
     , UtilByteString.tests
     , UtilEither.tests
     , UtilException.tests
+    , UtilHttp.tests
     , UtilLockable.tests
     , UtilNetwork.tests
     , UtilString.tests


### PR DESCRIPTION
  - All-lowercase "/sendraw" and "/receiveraw"
  - Renamed "from" header to "c11n-from" and "to" to "c11n-to"
  - Util.Http: New module
  - Util.Http functions: Support multiple headers with the same name, e.g.
    H1: v1,v2
    H1: v3
    is equivalent to H1: v1,v2,v3