### PR TITLE
Better receiveraw and fixed self-send bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.stack-work/
+.stack-work
 h
 *.key
 *.pub

--- a/Constellation/Enclave.hs
+++ b/Constellation/Enclave.hs
@@ -59,7 +59,7 @@ getCombinedKeys Enclave{..} sender rcpts = do
                 Nothing -> error "getCombinedKeys: Matching private key not found"
                 Just pk -> (k:ks, ncc, True)
                   where
-                    k   = safeBeforeNM (unPublicKey sender) pk (unPublicKey rcpt)
+                    !k  = safeBeforeNM (unPublicKey sender) pk (unPublicKey rcpt)
                     ncc = HM.insert (sender, rcpt) k cc
             Just k  -> (k:ks, cc, chd)
     when ccChanged $ writeTVar enclaveComboCache finalCc

--- a/Constellation/Enclave/Payload.hs
+++ b/Constellation/Enclave/Payload.hs
@@ -51,7 +51,10 @@ encrypt pl sender pk rcpts = encrypt' pl sender cks
   where
     cks = map (safeBeforeNM sender pk) rcpts
 
-safeBeforeNM :: Box.PublicKey -> Box.SecretKey -> Box.PublicKey -> Box.CombinedKey
+safeBeforeNM :: Box.PublicKey
+             -> Box.SecretKey
+             -> Box.PublicKey
+             -> Box.CombinedKey
 safeBeforeNM sender pk rcpt
     | sender == rcpt = error "safeBeforeNM: Sender cannot be a recipient"
     | otherwise      = Box.beforeNM pk rcpt

--- a/constellation.cabal
+++ b/constellation.cabal
@@ -64,7 +64,7 @@ library
                      , conduit >= 1.2.8
                      , connection >= 0.2.8
                      , containers >= 0.5.7
-                     , cryptonite >= 0.22
+                     , cryptonite >= 0.24
                      , data-default >= 0.7.1.1
                      , directory >= 1.2.6.2
                      , either >= 4.4

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-9.12
+resolver: lts-10.3
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -42,7 +42,6 @@ packages:
 # (e.g., acme-missiles-0.3)
 extra-deps:
   - BerkeleyDB-0.8.7
-  - cryptonite-0.22
   - logging-3.0.4
   - saltine-0.0.0.4
 


### PR DESCRIPTION
  - Update stack LTS

  - Make `receiveraw` not require JSON payload (i.e. put the key in the headers)

  - Fix self-send bug where unevaluated safeBeforeNM error gets stored in Enclave cache

Fixes https://github.com/jpmorganchase/constellation/issues/75
Fixes https://github.com/jpmorganchase/constellation/issues/70
Fixes https://github.com/jpmorganchase/constellation/issues/47