### PR TITLE
Enhancement debian package manager tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,11 @@ FROM ubuntu:xenial as builder
 
 RUN apt-get update
 
-RUN apt-get install -y curl && \
+RUN apt-get --no-install-recommends install -y apt-utils ca-certificates curl && \
     curl -sSL https://get.haskellstack.org/ | sh
 
-RUN apt-get install -y libgmp-dev libdb-dev libleveldb-dev libsodium-dev zlib1g-dev libtinfo-dev && \
-    apt-get install -y ruby ruby-dev build-essential && \
+RUN apt-get --no-install-recommends install -y libgmp-dev libdb-dev libleveldb-dev libsodium-dev zlib1g-dev libtinfo-dev && \
+    apt-get --no-install-recommends install -y ruby ruby-dev build-essential && \
     gem install --no-ri --no-rdoc fpm
 
 ENV SRC /usr/local/src/constellation
@@ -29,7 +29,7 @@ FROM ubuntu:xenial
 
 RUN mkdir -p /constellation
 RUN apt-get update
-RUN apt-get install -y libgmp-dev libdb-dev libleveldb-dev libsodium-dev zlib1g-dev libtinfo-dev build-essential curl
+RUN apt-get --no-install-recommends install -y apt-utils ca-certificates libgmp-dev libdb-dev libleveldb-dev libsodium-dev zlib1g-dev libtinfo-dev build-essential curl
 
 COPY --from=builder /usr/local/bin/constellation-node /usr/local/bin/
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ you to implement custom storage and encryption logic.
 ### Prerequisites
 
   1. Install supporting libraries:
-    - Ubuntu: `apt-get install libdb-dev libleveldb-dev libsodium-dev zlib1g-dev libtinfo-dev`
+    - Ubuntu: `apt-get --no-install-recommends install apt-utils ca-certificates libdb-dev libleveldb-dev libsodium-dev     zlib1g-dev libtinfo-dev`
+    
     - Red Hat: `dnf install libdb-devel leveldb-devel libsodium-devel zlib-devel ncurses-devel`
     - MacOS: `brew install berkeley-db leveldb libsodium`
 

--- a/scripts/travis-ci/upgrade-docker.sh
+++ b/scripts/travis-ci/upgrade-docker.sh
@@ -8,5 +8,5 @@ sudo sh -c 'echo "deb https://apt.dockerproject.org/repo ubuntu-trusty main" > /
 sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
 sudo apt-get update
 sudo apt-key update
-sudo apt-get -qqy -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install docker-engine=17.05.0~ce-0~ubuntu-trusty
+sudo apt-get --no-install-recommends -qqy -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install docker-engine=17.05.0~ce-0~ubuntu-trusty
 docker -v


### PR DESCRIPTION
Major Changes No 1 : debian package manager tweaks

By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Major Changes No 2 : added packages apt-utils ca-certificates

Because build is

1.  Slow because "apt-utils" not installed

2. to avoid build to exits with error without having certificate

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>